### PR TITLE
feat: persist team membership roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Variables básicas para ejecutar la app localmente
+FLASK_ENV=development
+SECRET_KEY=
+DATABASE_URL=
+ENABLE_REPORTS=0

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv/
 # Entorno / secretos
 .env
 .env.*
+!.env.example
 *.key
 *.pem
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Obyra Backend
+
+## Configuración local
+
+1. Crea un archivo `.env` a partir del template incluido:
+   ```bash
+   cp .env.example .env
+   ```
+2. Genera una clave secreta y colócala en el `.env`:
+   ```bash
+   flask --app app secret gen
+   ```
+   Copia el valor impreso y asígnalo a `SECRET_KEY` en tu `.env`.
+3. Define cualquier otra variable necesaria (por ejemplo `DATABASE_URL`) o deja que la app use SQLite por defecto en desarrollo.
+4. Si cambias la `SECRET_KEY`, cerrá la sesión en los navegadores o borrá la cookie `remember_token` desde las herramientas de desarrollador para evitar mensajes de sesión expirada.
+
+## Notas de despliegue
+
+- En producción es obligatorio definir `SECRET_KEY` antes de arrancar la aplicación; si falta, el proceso abortará con un error descriptivo.
+- En entornos de desarrollo, si `SECRET_KEY` no está definida se generará una clave temporal y se emitirá un *warning* en los logs. Esa clave solo dura mientras el proceso está activo, por lo que las sesiones se invalidarán en cada reinicio.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,77 @@
+"""Central configuration loader for the Flask application.
+
+This module centralizes environment handling for the project and ensures
+that required secrets are present before the rest of the app is
+initialized.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+def _to_bool(value: Optional[str], default: bool = False) -> bool:
+    """Convert environment strings to boolean flags."""
+
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+@dataclass
+class AppConfig:
+    """Representation of the runtime configuration for the app."""
+
+    flask_env: str = os.getenv("FLASK_ENV", "development")
+    secret_key: Optional[str] = os.getenv("SECRET_KEY")
+    enable_reports: bool = _to_bool(os.getenv("ENABLE_REPORTS"))
+    database_url: Optional[str] = os.getenv("DATABASE_URL")
+
+    def apply(self, app) -> None:
+        """Apply the configuration to the provided Flask app instance."""
+
+        env = (self.flask_env or "").strip() or "development"
+        env_lower = env.lower()
+        secret = self.secret_key
+
+        if env_lower == "production" and not secret:
+            raise RuntimeError(
+                "SECRET_KEY no configurada. Definila en tus variables de entorno"
+                " antes de iniciar la aplicación en producción."
+            )
+
+        if not secret:
+            secret = secrets.token_hex(32)
+            logging.warning(
+                "SECRET_KEY no definida. Se generó una clave temporal solo para"
+                " este proceso. Definí SECRET_KEY en tu .env para mantener las"
+                " sesiones activas entre reinicios."
+            )
+
+        self.secret_key = secret
+
+        app.config["SECRET_KEY"] = secret
+        app.secret_key = secret
+        app.config["FLASK_ENV"] = env_lower
+        app.config["ENABLE_REPORTS"] = self.enable_reports
+
+        if self.database_url:
+            app.config["DATABASE_URL"] = self.database_url
+
+
+def load_config(app) -> AppConfig:
+    """Load and apply the configuration, returning the data object."""
+
+    config = AppConfig()
+    config.apply(app)
+    return config
+

--- a/equipos.py
+++ b/equipos.py
@@ -1,9 +1,11 @@
 from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify
 from flask_login import login_required, current_user
 from app import db
-from models import Usuario, AsignacionObra, Obra, RegistroTiempo
+from models import Usuario, AsignacionObra, Obra, RegistroTiempo, OrgMembership
 from werkzeug.security import generate_password_hash
 from sqlalchemy.exc import IntegrityError
+from roles_construccion import obtener_roles_por_categoria
+import re
 
 equipos_bp = Blueprint('equipos', __name__)
 
@@ -58,15 +60,15 @@ def usuarios_nuevo():
     if current_user.rol not in ['administrador', 'admin_empresa', 'superadmin']:
         flash('No tienes permisos para crear usuarios.', 'danger')
         return redirect(url_for('auth.usuarios_admin'))
-    
-    from roles_construccion import ROLES_DISPONIBLES
+
     from models import RoleModule, upsert_user_module
-    
+    roles_catalog = obtener_roles_por_categoria()
+
     if request.method == 'GET':
         # Cargar permisos por rol seleccionado (default 'operario')
         role = request.args.get('role', 'operario')
         role_perms = RoleModule.query.filter_by(role=role).all()
-        return render_template('equipos/invitar.html', role=role, role_perms=role_perms, roles=ROLES_DISPONIBLES)
+        return render_template('equipos/invitar.html', role=role, role_perms=role_perms, roles=roles_catalog)
     
     # POST: crear usuario e invitar
     email = request.form.get('email')
@@ -135,9 +137,9 @@ def crear():
     if not current_user.puede_acceder_modulo('equipos') or current_user.rol != 'administrador':
         flash('No tienes permisos para crear usuarios.', 'danger')
         return redirect(url_for('equipos.lista'))
-    
-    from roles_construccion import ROLES_DISPONIBLES
-    
+
+    roles_catalog = obtener_roles_por_categoria()
+
     if request.method == 'POST':
         nombre = request.form.get('nombre')
         apellido = request.form.get('apellido')
@@ -150,26 +152,26 @@ def crear():
         # Validaciones
         if not all([nombre, apellido, email, rol, password]):
             flash('Por favor, completa todos los campos obligatorios.', 'danger')
-            return render_template('equipos/crear.html', roles=ROLES_DISPONIBLES)
+            return render_template('equipos/crear.html', roles=roles_catalog)
         
         # Validar formato de email
         import re
         if not re.match(r'^[^@]+@[^@]+\.[^@]+$', email):
             flash('Por favor, ingresa un email válido.', 'danger')
-            return render_template('equipos/crear.html', roles=ROLES_DISPONIBLES)
+            return render_template('equipos/crear.html', roles=roles_catalog)
         
         if password != confirm_password:
             flash('Las contraseñas no coinciden.', 'danger')
-            return render_template('equipos/crear.html', roles=ROLES_DISPONIBLES)
+            return render_template('equipos/crear.html', roles=roles_catalog)
         
         if len(password) < 6:
             flash('La contraseña debe tener al menos 6 caracteres.', 'danger')
-            return render_template('equipos/crear.html', roles=ROLES_DISPONIBLES)
+            return render_template('equipos/crear.html', roles=roles_catalog)
         
         # Verificar que el email no exista
         if Usuario.query.filter_by(email=email).first():
             flash('Ya existe un usuario con ese email.', 'danger')
-            return render_template('equipos/crear.html', roles=ROLES_DISPONIBLES)
+            return render_template('equipos/crear.html', roles=roles_catalog)
         
         try:
             from werkzeug.security import generate_password_hash
@@ -197,7 +199,7 @@ def crear():
             db.session.rollback()
             flash('Error al crear el usuario. Por favor, intenta de nuevo.', 'danger')
     
-    return render_template('equipos/crear.html', roles=ROLES_DISPONIBLES)
+    return render_template('equipos/crear.html', roles=roles_catalog)
 
 @equipos_bp.route('/<int:id>')
 @login_required
@@ -229,36 +231,66 @@ def editar(id):
     if current_user.rol != 'administrador':
         flash('No tienes permisos para editar usuarios.', 'danger')
         return redirect(url_for('equipos.detalle', id=id))
-    
+
     usuario = Usuario.query.get_or_404(id)
-    from roles_construccion import ROLES_DISPONIBLES
-    
+    roles_catalog = obtener_roles_por_categoria()
+    roles_validos = {rol for lista in roles_catalog.values() for rol in lista}
+    membership = usuario.active_membership
+    rol_actual = membership.role if membership else usuario.rol
+
     if request.method == 'POST':
         usuario.nombre = request.form.get('nombre', usuario.nombre)
         usuario.apellido = request.form.get('apellido', usuario.apellido)
         usuario.email = request.form.get('email', usuario.email)
         usuario.telefono = request.form.get('telefono', usuario.telefono)
-        usuario.rol = request.form.get('rol', usuario.rol)
-        
+        nuevo_rol = request.form.get('rol')
+
+        if not nuevo_rol:
+            flash('Debes seleccionar un rol organizacional.', 'danger')
+            return render_template('equipos/editar.html', usuario=usuario, roles=roles_catalog, rol_seleccionado=rol_actual)
+
+        if nuevo_rol not in roles_validos:
+            flash('El rol seleccionado no es válido.', 'danger')
+            return render_template('equipos/editar.html', usuario=usuario, roles=roles_catalog, rol_seleccionado=rol_actual)
+
         # Validar email único
         email_existente = Usuario.query.filter(
             Usuario.email == usuario.email,
             Usuario.id != usuario.id
         ).first()
-        
+
         if email_existente:
             flash('Ya existe otro usuario con ese email.', 'danger')
-            return render_template('equipos/editar.html', usuario=usuario, roles=ROLES_DISPONIBLES)
-        
+            return render_template('equipos/editar.html', usuario=usuario, roles=roles_catalog, rol_seleccionado=nuevo_rol)
+
+        rol_actual = nuevo_rol
+
         try:
+            # Asegurar membresía activa en la organización actual
+            membership = usuario.active_membership
+            if membership:
+                membership.role = nuevo_rol
+                membership.is_active = True
+            else:
+                membership = OrgMembership(
+                    user_id=usuario.id,
+                    organization_id=usuario.organizacion_id,
+                    role=nuevo_rol,
+                    is_active=True
+                )
+                db.session.add(membership)
+
+            # Mantener sincronizado el campo legacy mientras migramos a RBAC por membresía
+            usuario.rol = nuevo_rol
+
             db.session.commit()
             flash('Usuario actualizado exitosamente.', 'success')
             return redirect(url_for('equipos.detalle', id=id))
         except Exception as e:
             db.session.rollback()
             flash('Error al actualizar el usuario.', 'danger')
-    
-    return render_template('equipos/editar.html', usuario=usuario, roles=ROLES_DISPONIBLES)
+
+    return render_template('equipos/editar.html', usuario=usuario, roles=roles_catalog, rol_seleccionado=rol_actual)
 
 @equipos_bp.route('/<int:id>/toggle', methods=['POST'])
 @login_required

--- a/models.py
+++ b/models.py
@@ -20,6 +20,7 @@ class Organizacion(db.Model):
     usuarios = db.relationship('Usuario', back_populates='organizacion', lazy='dynamic')
     obras = db.relationship('Obra', back_populates='organizacion', lazy='dynamic')
     inventario = db.relationship('ItemInventario', back_populates='organizacion', lazy='dynamic')
+    memberships = db.relationship('OrgMembership', back_populates='organization', lazy='dynamic')
     presupuestos = db.relationship('Presupuesto', lazy='dynamic')
     
     def __repr__(self):
@@ -70,6 +71,7 @@ class Usuario(UserMixin, db.Model):
     organizacion = db.relationship('Organizacion', back_populates='usuarios')
     obras_asignadas = db.relationship('AsignacionObra', back_populates='usuario', lazy='dynamic')
     registros_tiempo = db.relationship('RegistroTiempo', back_populates='usuario', lazy='dynamic')
+    memberships = db.relationship('OrgMembership', back_populates='user', lazy='dynamic')
     
     def __repr__(self):
         return f'<Usuario {self.nombre} {self.apellido}>'
@@ -99,7 +101,23 @@ class Usuario(UserMixin, db.Model):
     @property
     def nombre_completo(self):
         return f"{self.nombre} {self.apellido}"
-    
+
+    @property
+    def active_membership(self):
+        """Retorna la membresía activa del usuario dentro de su organización."""
+        if not self.organizacion_id:
+            return None
+        return self.memberships.filter_by(
+            organization_id=self.organizacion_id,
+            is_active=True
+        ).first()
+
+    @property
+    def rol_organizacion(self):
+        """Obtiene el rol asignado en la membresía activa, con fallback al campo legacy."""
+        membership = self.active_membership
+        return membership.role if membership else self.rol
+
     def puede_acceder_modulo(self, modulo):
         """Verifica si el usuario puede acceder a un módulo usando RBAC"""
         # Primero verificar si hay override específico de usuario
@@ -197,16 +215,42 @@ class Usuario(UserMixin, db.Model):
         # Administradores especiales tienen acceso completo
         if self.es_admin_completo():
             return True
-        
+
         # Usuarios con planes activos (standard/premium) también tienen acceso
         if self.plan_activo in ['standard', 'premium']:
             return True
-            
+
         # Usuarios en periodo de prueba válido
         if self.plan_activo == 'prueba' and self.esta_en_periodo_prueba():
             return True
-            
+
         return False
+
+
+class OrgMembership(db.Model):
+    __tablename__ = 'org_memberships'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=False)
+    organization_id = db.Column(db.Integer, db.ForeignKey('organizaciones.id'), nullable=False)
+    role = db.Column(db.String(100), nullable=False)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    user = db.relationship('Usuario', back_populates='memberships')
+    organization = db.relationship('Organizacion', back_populates='memberships')
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'organization_id', name='uq_org_membership_user_org'),
+    )
+
+    def __repr__(self):
+        return f'<OrgMembership user={self.user_id} org={self.organization_id} role={self.role}>'
+
+    def deactivate(self):
+        """Marca la membresía como inactiva."""
+        self.is_active = False
 
 
 class Obra(db.Model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,5 @@ dependencies = [
     "matplotlib>=3.10.5",
     "pillow>=11.3.0",
     "mercadopago>=2.3.0",
+    "python-dotenv>=1.0.1",
 ]

--- a/templates/equipos/editar.html
+++ b/templates/equipos/editar.html
@@ -50,8 +50,8 @@
                                 {% for categoria, roles_lista in roles.items() %}
                                     <optgroup label="{{ categoria }}">
                                         {% for rol in roles_lista %}
-                                            <option value="{{ rol }}" 
-                                                    {% if usuario.rol == rol %}selected{% endif %}>
+                                            <option value="{{ rol }}"
+                                                    {% if rol_seleccionado == rol %}selected{% endif %}>
                                                 {{ rol|title }}
                                             </option>
                                         {% endfor %}


### PR DESCRIPTION
## Summary
- add an OrgMembership model to capture active organization roles per user
- update team management flows to fetch role catalogs and sync the membership when editing members
- surface the selected organizational role in the edit form so the correct value is shown after updates

## Testing
- python -m compileall equipos.py models.py roles_construccion.py

------
https://chatgpt.com/codex/tasks/task_e_68e141fb55e88322a71aca4d756d96e8