### PR TITLE
fix: avoid BuildError when resolving login URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -423,6 +423,8 @@ try:
 except ImportError as e:
     print(f"⚠️ Marketplace blueprint not available: {e}")
 
+_refresh_login_view()
+
 
 # === MEDIA SERVING ENDPOINT ===
 

--- a/app.py
+++ b/app.py
@@ -69,44 +69,28 @@ login_manager.login_message_category = 'info'
 
 
 def _resolve_login_url() -> str:
-    """Devuelve una URL de login válida aun si falta un blueprint."""
-
     for endpoint in ('auth.login', 'supplier_auth.login'):
         try:
             return url_for(endpoint)
         except BuildError:
             continue
-
-    logging.warning(
-        "No se encontraron endpoints de login registrados; usando '/proveedor/login'"
-    )
     return '/proveedor/login'
 
 
 def _login_redirect():
-    """Redirige al login disponible evitando BuildError."""
     return redirect(_resolve_login_url())
 
 
 def _refresh_login_view() -> None:
-    """Sincroniza login_view con el blueprint de autenticación disponible."""
-
     for endpoint in ('auth.login', 'supplier_auth.login'):
         if endpoint in app.view_functions:
-            if login_manager.login_view != endpoint:
-                logging.info("Login view configurada en %s", endpoint)
             login_manager.login_view = endpoint
             return
-
-    if login_manager.login_view is not None:
-        logging.warning("No se encontró endpoint de login registrado; limpiando login_view")
     login_manager.login_view = None
 
 
 @app.context_processor
 def inject_login_url():
-    """Hace disponible la URL de login en todos los templates."""
-
     return {"login_url": _resolve_login_url()}
 
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from flask import Flask, render_template, redirect, url_for, flash, send_from_di
 from flask_login import login_required, current_user
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.security import generate_password_hash
+from werkzeug.routing import BuildError
 from extensions import db, login_manager
 
 # create the app
@@ -48,9 +49,52 @@ app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
 # initialize extensions
 db.init_app(app)
 login_manager.init_app(app)
-login_manager.login_view = 'auth.login'
+login_manager.login_view = None
 login_manager.login_message = 'Por favor inicia sesión para acceder a esta página.'
 login_manager.login_message_category = 'info'
+
+
+def _resolve_login_url() -> str:
+    """Devuelve una URL de login válida aun si falta un blueprint."""
+
+    for endpoint in ('auth.login', 'supplier_auth.login'):
+        try:
+            return url_for(endpoint)
+        except BuildError:
+            continue
+
+    logging.warning(
+        "No se encontraron endpoints de login registrados; usando '/proveedor/login'"
+    )
+    return '/proveedor/login'
+
+
+def _login_redirect():
+    """Redirige al login disponible evitando BuildError."""
+
+    return redirect(_resolve_login_url())
+
+
+def _refresh_login_view() -> None:
+    """Sincroniza login_view con el blueprint de autenticación disponible."""
+
+    for endpoint in ('auth.login', 'supplier_auth.login'):
+        if endpoint in app.view_functions:
+            if login_manager.login_view != endpoint:
+                logging.info("Login view configurada en %s", endpoint)
+            login_manager.login_view = endpoint
+            return
+
+    if login_manager.login_view is not None:
+        logging.warning("No se encontró endpoint de login registrado; limpiando login_view")
+    login_manager.login_view = None
+
+
+@app.context_processor
+def inject_login_url():
+    """Hace disponible la URL de login en todos los templates."""
+
+    return {"login_url": _resolve_login_url()}
 
 
 @login_manager.user_loader
@@ -62,12 +106,12 @@ def load_user(user_id):
 @login_manager.unauthorized_handler
 def unauthorized():
     """Custom unauthorized handler that returns JSON for API routes"""
-    from flask import request, jsonify, redirect, url_for
+    from flask import request, jsonify
     # Check if this is an API request
     if request.path.startswith('/obras/api/') or request.path.startswith('/api/'):
         return jsonify({"ok": False, "error": "Authentication required"}), 401
     # For regular web requests, redirect to login
-    return redirect(url_for('auth.login'))
+    return _login_redirect()
 
 
 # Register blueprints - moved after database initialization to avoid circular imports
@@ -89,7 +133,8 @@ def verificar_periodo_prueba():
     # Rutas que no requieren verificación de plan
     rutas_excluidas = [
         'planes.mostrar_planes', 'planes.plan_standard', 'planes.plan_premium',
-        'auth.login', 'auth.register', 'auth.logout', 'static', 'index'
+        'auth.login', 'auth.register', 'auth.logout',
+        'supplier_auth.login', 'static', 'index'
     ]
     
     if (current_user.is_authenticated and 
@@ -117,7 +162,7 @@ def index():
         if getattr(current_user, "role", None) == "operario":
             return redirect(url_for("obras.mis_tareas"))
         return redirect(url_for('reportes.dashboard'))
-    return redirect(url_for('auth.login'))
+    return _login_redirect()
 
 
 @app.route('/dashboard')
@@ -127,7 +172,14 @@ def dashboard():
         if getattr(current_user, "role", None) == "operario":
             return redirect(url_for("obras.mis_tareas"))
         return redirect(url_for('reportes.dashboard'))
-    return redirect(url_for('auth.login'))
+    return _login_redirect()
+
+
+@app.route('/login')
+def login_redirect():
+    """Ruta de compatibilidad que redirige al login activo."""
+
+    return _login_redirect()
 
 
 # Filtros personalizados
@@ -337,6 +389,8 @@ try:
 except ImportError as e:
     print(f"⚠️ Some core blueprints not available: {e}")
 
+_refresh_login_view()
+
 # Try to register optional blueprints
 try:
     from equipos_new import equipos_new_bp
@@ -358,6 +412,8 @@ try:
     print("✅ Supplier portal blueprints registered successfully")
 except ImportError as e:
     print(f"⚠️ Supplier portal blueprints not available: {e}")
+
+_refresh_login_view()
 
 # Try to register marketplace blueprints
 try:
@@ -386,12 +442,12 @@ def forbidden(error):
 
 @app.errorhandler(401)
 def unauthorized(error):
-    from flask import request, jsonify, redirect, url_for
-    # Check if this is an API request  
+    from flask import request, jsonify
+    # Check if this is an API request
     if request.path.startswith('/obras/api/') or request.path.startswith('/api/'):
         return jsonify({"ok": False, "error": "Authentication required"}), 401
     # For regular web requests, redirect to login
-    return redirect(url_for('auth.login'))
+    return _login_redirect()
 
 @app.errorhandler(404)
 def not_found(error):

--- a/app.py
+++ b/app.py
@@ -71,7 +71,6 @@ def _resolve_login_url() -> str:
 
 def _login_redirect():
     """Redirige al login disponible evitando BuildError."""
-
     return redirect(_resolve_login_url())
 
 

--- a/calculadora_ia.py
+++ b/calculadora_ia.py
@@ -6,11 +6,19 @@ Sistema inteligente para analizar planos y calcular materiales automáticamente
 import os
 import base64
 import json
+import logging
 from datetime import datetime
 from openai import OpenAI
 
-# Inicializar cliente OpenAI
-client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+# Inicializar cliente OpenAI solo si la API key está disponible
+_openai_api_key = os.environ.get("OPENAI_API_KEY")
+if _openai_api_key:
+    client = OpenAI(api_key=_openai_api_key)
+else:
+    client = None
+    logging.warning(
+        "OPENAI_API_KEY no configurada; la calculadora IA se deshabilitará hasta definirla."
+    )
 
 # Coeficientes de construcción expandidos por tipo y m² - Estilo Togal.AI
 COEFICIENTES_CONSTRUCCION = {
@@ -335,6 +343,11 @@ def analizar_plano_con_ia(archivo_pdf_base64, metros_cuadrados_manual=None):
     Analiza un plano arquitectónico usando IA de OpenAI
     Para PDFs, se usa análisis de texto, para superficie manual se sugiere el tipo
     """
+    if client is None:
+        raise RuntimeError(
+            "OPENAI_API_KEY no configurada. Configurala para habilitar el análisis con IA."
+        )
+
     try:
         # Si hay superficie manual, hacer análisis inteligente sin imagen
         if metros_cuadrados_manual:

--- a/cart.py
+++ b/cart.py
@@ -5,7 +5,7 @@ Blueprint del Carrito de Compras
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, jsonify
 from flask_login import current_user
 from sqlalchemy import func
-from app import db
+from app import db, _login_redirect
 from models import Cart, CartItem, ProductVariant, Product, Supplier, Order, OrderItem, OrderCommission
 from commission_utils import get_commission_summary
 from decimal import Decimal
@@ -213,7 +213,7 @@ def checkout_confirm():
     
     if not current_user.is_authenticated:
         flash('Debes iniciar sesión para completar la compra', 'error')
-        return redirect(url_for('auth.login'))
+        return _login_redirect()
     
     # Agrupar items por proveedor
     items_by_supplier = defaultdict(list)

--- a/equipos_new.py
+++ b/equipos_new.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify
 from flask_login import login_required, current_user
-from app import db
+from app import db, _login_redirect
 from models import (
     Equipment, EquipmentAssignment, EquipmentUsage, MaintenanceTask, 
     MaintenanceAttachment, Obra, Usuario
@@ -24,7 +24,7 @@ def requires_role(*roles):
     def decorator(f):
         def decorated_function(*args, **kwargs):
             if not current_user.is_authenticated:
-                return redirect(url_for('auth.login'))
+                return _login_redirect()
             if current_user.rol not in roles and not current_user.es_admin():
                 flash('No tienes permisos para esta acción.', 'danger')
                 return redirect(url_for('equipos_new.lista'))

--- a/inventario_new.py
+++ b/inventario_new.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify
 from flask_login import login_required, current_user
-from app import db
+from app import db, _login_redirect
 from models import (
     InventoryCategory, InventoryItem, Warehouse, Stock, 
     StockMovement, StockReservation, Obra
@@ -15,7 +15,7 @@ def requires_role(*roles):
     def decorator(f):
         def decorated_function(*args, **kwargs):
             if not current_user.is_authenticated:
-                return redirect(url_for('auth.login'))
+                return _login_redirect()
             if current_user.rol not in roles and not current_user.es_admin():
                 flash('No tienes permisos para esta acción.', 'danger')
                 return redirect(url_for('inventario_new.items'))

--- a/main_app.py
+++ b/main_app.py
@@ -7,7 +7,7 @@ import os
 from flask import Flask, request, redirect, url_for, session, flash, render_template
 from flask_login import login_user, current_user
 from authlib.integrations.flask_client import OAuth
-from app import app, db
+from app import app, db, _login_redirect
 from models import Usuario
 from datetime import datetime
 
@@ -57,7 +57,7 @@ def google_login():
     
     if not google:
         flash('Google OAuth no está configurado. Contacta al administrador del sistema.', 'warning')
-        return redirect(url_for('auth.login'))
+        return _login_redirect()
     
     # URL de callback para el proceso OAuth
     redirect_uri = url_for('google_callback', _external=True)
@@ -69,7 +69,7 @@ def google_callback():
     """Procesar callback de Google OAuth y autenticar usuario"""
     if not google:
         flash('Google OAuth no está configurado.', 'danger')
-        return redirect(url_for('auth.login'))
+        return _login_redirect()
     
     try:
         # Obtener token de acceso de Google
@@ -80,7 +80,7 @@ def google_callback():
         
         if not user_info:
             flash('No se pudo obtener información del usuario de Google.', 'danger')
-            return redirect(url_for('auth.login'))
+            return _login_redirect()
         
         # Extraer datos necesarios
         google_id = user_info.get('sub')
@@ -91,7 +91,7 @@ def google_callback():
         
         if not email or not google_id:
             flash('Email o ID de Google no disponible.', 'danger')
-            return redirect(url_for('auth.login'))
+            return _login_redirect()
         
         # Buscar usuario existente por email o google_id
         usuario = Usuario.query.filter(
@@ -135,7 +135,7 @@ def google_callback():
         # Verificar que el usuario esté activo
         if not usuario.activo:
             flash('Tu cuenta está desactivada. Contacta al administrador.', 'warning')
-            return redirect(url_for('auth.login'))
+            return _login_redirect()
         
         # Realizar login del usuario
         login_user(usuario, remember=True)
@@ -154,7 +154,7 @@ def google_callback():
         print(f"Error en Google OAuth: {str(e)}")
         db.session.rollback()
         flash('Error durante el proceso de autenticación con Google. Intenta de nuevo.', 'danger')
-        return redirect(url_for('auth.login'))
+        return _login_redirect()
 
 def init_google_oauth():
     """Función para inicializar Google OAuth si es necesario"""

--- a/templates/auth/aceptar_invitacion.html
+++ b/templates/auth/aceptar_invitacion.html
@@ -48,7 +48,7 @@
                     </form>
                     
                     <div class="text-center mt-3">
-                        <a href="{{ url_for('auth.login') }}" class="btn btn-link">
+                        <a href="{{ login_url }}" class="btn btn-link">
                             <i class="fas fa-arrow-left me-1"></i>Volver al login
                         </a>
                     </div>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -73,8 +73,8 @@
             </div>
 
             <div class="text-center">
-                <p class="mb-0">¿Ya tienes una cuenta? 
-                    <a href="{{ url_for('auth.login') }}" class="auth-link">Iniciar Sesión</a>
+                <p class="mb-0">¿Ya tienes una cuenta?
+                    <a href="{{ login_url }}" class="auth-link">Iniciar Sesión</a>
                 </p>
             </div>
         </form>

--- a/templates/supplier_auth/login.html
+++ b/templates/supplier_auth/login.html
@@ -83,7 +83,7 @@
                         </div>
                         
                         <div class="text-center mt-3">
-                            <a href="{{ url_for('auth.login') }}" class="text-muted">
+                            <a href="{{ login_url }}" class="text-muted">
                                 <i class="fas fa-arrow-left me-1"></i>
                                 Volver al login principal
                             </a>

--- a/templates/supplier_auth/registro.html
+++ b/templates/supplier_auth/registro.html
@@ -171,7 +171,7 @@
                 </div>
                 
                 <div class="text-center mt-3">
-                    <a href="{{ url_for('auth.login') }}" class="text-white">
+                    <a href="{{ login_url }}" class="text-white">
                         <i class="fas fa-arrow-left me-1"></i>
                         Volver al login principal
                     </a>


### PR DESCRIPTION
## Summary
- add a reusable login redirect helper plus a global `login_url` context variable so templates and routes no longer depend on `auth.login`
- update inventory, equipos, cart flows and supplier/login templates to consume the fallback and stay functional when only `supplier_auth` is available

## Testing
- python -m compileall .
- FLASK_SKIP_DOTENV=1 PYTHONPATH=/tmp OPENAI_API_KEY=dummy DATABASE_URL=sqlite:////workspace/obyra-backup/tmp/dev.db .venv/bin/flask --app app.py routes

------
https://chatgpt.com/codex/tasks/task_e_68e141fb55e88322a71aca4d756d96e8