### PR TITLE
Fix login resolver and maintain gunicorn loading fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,18 @@ import importlib
 import click
 from decimal import Decimal, InvalidOperation
 from typing import Optional
-from flask import Flask, render_template, redirect, url_for, flash, send_from_directory, request, g, session
+from flask import (
+    Flask,
+    render_template,
+    redirect,
+    url_for,
+    flash,
+    send_from_directory,
+    request,
+    g,
+    session,
+    has_request_context,
+)
 from flask.cli import AppGroup
 from flask_login import login_required, current_user
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -75,26 +86,61 @@ app.config["MAPS_API_KEY"] = os.environ.get("MAPS_API_KEY")
 # initialize extensions
 db.init_app(app)
 login_manager.init_app(app)
-def _resolve_login_endpoint(app) -> str:
-    """Return the first available login endpoint, falling back to the landing page."""
+
+
+def _resolve_login_endpoint() -> Optional[str]:
+    """Return the first available login endpoint, prioritising auth blueprints."""
 
     candidate_endpoints = (
-        'auth.login',
-        'supplier_auth.login',
-        'auth_login',
-        'index',
+        "auth.login",
+        "supplier_auth.login",
+        "auth_login",
+        "index",
     )
 
     for endpoint in candidate_endpoints:
         if endpoint in app.view_functions:
             return endpoint
 
-    return 'index'
+    return None
 
 
-login_manager.login_view = 'index'
+def _resolve_login_url() -> str:
+    """Return the URL corresponding to the active login endpoint."""
+
+    endpoint = _resolve_login_endpoint()
+    if not endpoint:
+        return "/"
+
+    try:
+        if has_request_context():
+            return url_for(endpoint)
+        with app.test_request_context():
+            return url_for(endpoint)
+    except Exception:
+        return "/"
+
+
+def _login_redirect():
+    """Redirect users to the most appropriate login page."""
+
+    return redirect(_resolve_login_url())
+
+
+def _refresh_login_view():
+    """Synchronise the login manager with the currently available login endpoint."""
+
+    login_manager.login_view = _resolve_login_endpoint()
+
+
+login_manager.login_view = None
 login_manager.login_message = 'Por favor inicia sesión para acceder a esta página.'
 login_manager.login_message_category = 'info'
+
+
+@app.context_processor
+def inject_login_url():
+    return {"login_url": _resolve_login_url()}
 
 db_cli = AppGroup('db')
 
@@ -406,7 +452,7 @@ def index():
 @app.route('/login', endpoint='auth_login')
 def legacy_login_redirect():
     """Mantener compatibilidad con rutas antiguas /login"""
-    return redirect(url_for('auth.login'))
+    return _login_redirect()
 
 
 @app.route('/dashboard')
@@ -416,7 +462,7 @@ def dashboard():
         if getattr(current_user, "role", None) == "operario":
             return redirect(url_for("obras.mis_tareas"))
         return redirect(url_for('reportes.dashboard'))
-    return redirect(url_for('auth.login'))
+    return _login_redirect()
 
 
 # Filtros personalizados
@@ -720,6 +766,8 @@ if core_failures:
 else:
     print("✅ Core blueprints registered successfully")
 
+_refresh_login_view()
+
 if app.config.get("ENABLE_REPORTS_SERVICE"):
     try:
         import matplotlib  # noqa: F401 - sanity check for optional dependency
@@ -772,6 +820,8 @@ try:
 except ImportError as e:
     print(f"⚠️ Supplier portal blueprints not available: {e}")
 
+_refresh_login_view()
+
 # Try to register marketplace blueprints
 try:
     from marketplace.routes import bp as marketplace_bp
@@ -780,7 +830,7 @@ try:
 except ImportError as e:
     print(f"⚠️ Marketplace blueprint not available: {e}")
 
-login_manager.login_view = _resolve_login_endpoint(app)
+_refresh_login_view()
 
 
 # --- Public legal pages fallbacks ---------------------------------------
@@ -848,7 +898,7 @@ def unauthorized(error):
     if request.path.startswith('/obras/api/') or request.path.startswith('/api/'):
         return jsonify({"ok": False, "error": "Authentication required"}), 401
     # For regular web requests, redirect to login
-    return redirect(url_for('auth.login'))
+    return _login_redirect()
 
 @app.errorhandler(404)
 def not_found(error):


### PR DESCRIPTION
## Summary
- add dynamic login resolver helpers with context processor and redirects
- update login redirects and unauthorized handler to use the helper
- refresh login manager mapping after blueprint registration to keep gunicorn fixes intact

## Testing
- python -m compileall .
- FLASK_SKIP_DOTENV=1 PYTHONPATH=/tmp OPENAI_API_KEY=dummy DATABASE_URL=sqlite:////workspace/obyra-backup/tmp/dev.db .venv/bin/flask --app app.py routes | grep -E "auth.login|supplier_auth.login|^/login$" || true

------
https://chatgpt.com/codex/tasks/task_e_68e30337ef608322bc688630581e1936