### PR TITLE
Restrict inventory category management to superadmins

### DIFF
--- a/inventario.py
+++ b/inventario.py
@@ -34,6 +34,7 @@ from inventory_category_service import (
     ensure_categories_for_company_id,
     serialize_category,
     render_category_catalog,
+    user_can_manage_inventory_categories,
 )
 
 
@@ -297,6 +298,10 @@ def categorias():
         flash('No tienes permisos para acceder al catálogo de categorías.', 'danger')
         return redirect(url_for('reportes.dashboard'))
 
+    if not user_can_manage_inventory_categories(current_user):
+        flash('No tienes permisos para gestionar el catálogo global de categorías.', 'danger')
+        return redirect(url_for('inventario.lista'))
+
     company_id = _resolve_company_id()
     if not company_id:
         flash('No pudimos determinar la organización actual.', 'warning')
@@ -361,6 +366,10 @@ def crear_categoria():
         flash('No tienes permisos para actualizar el catálogo.', 'danger')
         return redirect(url_for('inventario.categorias'))
 
+    if not user_can_manage_inventory_categories(current_user):
+        flash('No tienes permisos para modificar el catálogo global.', 'danger')
+        return redirect(url_for('inventario.lista'))
+
     company_id = _resolve_company_id()
     if not company_id:
         flash('No pudimos determinar la organización actual.', 'warning')
@@ -371,7 +380,7 @@ def crear_categoria():
         flash('No encontramos la organización seleccionada.', 'danger')
         return redirect(url_for('inventario.categorias'))
 
-    stats = seed_inventory_categories_for_company(company)
+    stats = seed_inventory_categories_for_company(company, mark_global=True)
     db.session.commit()
 
     created = stats.get('created', 0)

--- a/models.py
+++ b/models.py
@@ -1908,6 +1908,7 @@ class InventoryCategory(db.Model):
     parent_id = db.Column(db.Integer, db.ForeignKey('inventory_category.id'))
     sort_order = db.Column(db.Integer, nullable=False, default=0)
     is_active = db.Column(db.Boolean, nullable=False, default=True)
+    is_global = db.Column(db.Boolean, nullable=False, default=False, index=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Relaciones

--- a/templates/inventario/crear.html
+++ b/templates/inventario/crear.html
@@ -37,8 +37,12 @@
                                     </select>
                                     <div class="form-text text-warning" data-category-empty {% if categorias %}hidden{% endif %}>
                                         <i class="fas fa-exclamation-triangle me-1"></i>
-                                        No hay categorías disponibles.
-                                        <a href="{{ url_for('inventario.categorias') }}">Crear una categoría primero</a>.
+                                        {% if can_manage_categories|default(False) %}
+                                            No hay categorías disponibles.
+                                            <a href="{{ url_for('inventario.categorias') }}">Gestioná el catálogo global</a>.
+                                        {% else %}
+                                            No hay categorías disponibles. Tu superadministrador debe habilitar el catálogo.
+                                        {% endif %}
                                     </div>
                                 </div>
                             </div>

--- a/templates/inventario_new/item_form.html
+++ b/templates/inventario_new/item_form.html
@@ -48,7 +48,12 @@
                             </select>
                             <div class="form-text text-warning" data-category-empty {% if categorias %}hidden{% endif %}>
                                 <i class="fas fa-info-circle me-1"></i>
-                                Necesitas crear categorías primero
+                                {% if can_manage_categories %}
+                                    No hay categorías disponibles.
+                                    <a href="{{ url_for('inventario.categorias') }}">Gestioná el catálogo global</a>.
+                                {% else %}
+                                    No hay categorías disponibles. Tu superadministrador debe habilitar el catálogo.
+                                {% endif %}
                             </div>
                         </div>
                         
@@ -118,42 +123,17 @@
                                     <i class="fas fa-times me-2"></i>
                                     Cancelar
                                 </a>
-                                {% if not categorias %}
-                                    <button type="button" class="btn btn-info" data-bs-toggle="modal" data-bs-target="#categoriaModal">
-                                        <i class="fas fa-plus me-2"></i>
-                                        Crear Categoría
-                                    </button>
+                                {% if can_manage_categories %}
+                                    <a href="{{ url_for('inventario.categorias') }}" class="btn btn-info">
+                                        <i class="fas fa-sitemap me-2"></i>
+                                        Gestionar categorías
+                                    </a>
                                 {% endif %}
                             </div>
                         </div>
                     </form>
                 </div>
             </div>
-        </div>
-    </div>
-</div>
-
-<!-- Modal para crear categoría rápida -->
-<div class="modal fade" id="categoriaModal" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <form id="categoriaForm">
-                <div class="modal-header">
-                    <h5 class="modal-title">Nueva Categoría</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label" for="modal_categoria_nombre">Nombre de la Categoría</label>
-                        <input type="text" id="modal_categoria_nombre" name="nombre" class="form-control" required
-                               placeholder="Ej: Materiales, Herramientas, EPP">
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-info">Crear Categoría</button>
-                </div>
-            </form>
         </div>
     </div>
 </div>
@@ -251,24 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('obyra:org-changed', refreshCategories);
     document.addEventListener('obyra:inventory-categories:refresh', refreshCategories);
 
-    const categoriaForm = document.getElementById('categoriaForm');
-    if (categoriaForm) {
-        categoriaForm.addEventListener('submit', (event) => {
-            event.preventDefault();
-            alert('Para crear categorías, usa el módulo de configuración del inventario');
-            const modalElement = document.getElementById('categoriaModal');
-            if (modalElement) {
-                const modalInstance = (window.bootstrap && window.bootstrap.Modal.getInstance)
-                    ? window.bootstrap.Modal.getInstance(modalElement)
-                    : null;
-                if (modalInstance) {
-                    modalInstance.hide();
-                } else if (window.bootstrap && window.bootstrap.Modal) {
-                    new window.bootstrap.Modal(modalElement).hide();
-                }
-            }
-        });
-    }
 });
 </script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- add an `is_global` flag to inventory categories and update the service/seed helpers to manage a single global catalogue
- gate category management routes and manual seed endpoints behind the superadmin role while serving global categories through the API
- simplify inventory item forms to only reference the global catalogue and hide creation prompts for non-superadmin users

## Testing
- python -m compileall inventario.py inventario_new.py inventory_category_service.py seed_inventory_categories.py

------
https://chatgpt.com/codex/tasks/task_e_68e592c0f7888322ad2b6692c1a403ca