### PR TITLE
Require Postgres and seed inventory categories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Base de datos (PostgreSQL obligatorio)
+DATABASE_URL=postgresql+psycopg2://obyra:postgres@localhost:5432/obyra_dev
+
+# Funcionalidades opcionales
+SHOW_IA_CALCULATOR_BUTTON=0
+ENABLE_REPORTS=1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: dev-db migrate seed-categories
+
+dev-db:
+	docker-compose up -d db
+
+migrate:
+	alembic upgrade head
+
+seed-categories:
+	python seed_inventory_categories.py --global

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = sqlite:///placeholder.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s [%(name)s] %(message)s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: obyra
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: obyra_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U obyra -d obyra_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+from logging.config import fileConfig
+
+from alembic import context
+from extensions import db
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+logger = logging.getLogger('alembic.env')
+
+from app import app  # noqa: E402  pylint: disable=wrong-import-position
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+# target_metadata = None
+target_metadata = db.metadata
+
+
+def _configure_url_from_app() -> str:
+    url = app.config["SQLALCHEMY_DATABASE_URI"]
+    config.set_main_option("sqlalchemy.url", url)
+    return url
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = _configure_url_from_app()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+        compare_server_default=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    _configure_url_from_app()
+
+    with app.app_context():
+        connectable = db.engine
+
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+                compare_type=True,
+                compare_server_default=True,
+            )
+
+            with context.begin_transaction():
+                context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,14 @@
+"""${message}"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/migrations/versions/0001_initial_schema.py
+++ b/migrations/versions/0001_initial_schema.py
@@ -1,0 +1,30 @@
+"""Initial database schema."""
+
+from __future__ import annotations
+
+from alembic import op
+
+from app import app
+from extensions import db
+
+# revision identifiers, used by Alembic.
+revision = '0001_initial_schema'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create all tables defined in SQLAlchemy metadata."""
+
+    with app.app_context():
+        bind = op.get_bind()
+        db.metadata.create_all(bind=bind, checkfirst=True)
+
+
+def downgrade() -> None:
+    """Drop all tables created by this migration."""
+
+    with app.app_context():
+        bind = op.get_bind()
+        db.metadata.drop_all(bind=bind, checkfirst=True)

--- a/migrations/versions/0002_add_inventory_category_columns.py
+++ b/migrations/versions/0002_add_inventory_category_columns.py
@@ -1,0 +1,61 @@
+"""Ensure inventory_category has sort_order and status flags."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = '0002_add_inventory_category_columns'
+down_revision = '0001_initial_schema'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    try:
+        columns = {column['name'] for column in inspector.get_columns('inventory_category')}
+    except Exception:  # pragma: no cover - table missing
+        columns = set()
+
+    if 'sort_order' not in columns:
+        op.add_column('inventory_category', sa.Column('sort_order', sa.Integer(), nullable=True))
+        op.execute('UPDATE inventory_category SET sort_order = 0 WHERE sort_order IS NULL')
+        op.alter_column('inventory_category', 'sort_order', nullable=False, server_default=sa.text('0'))
+    else:
+        op.alter_column('inventory_category', 'sort_order', server_default=sa.text('0'))
+
+    if 'is_active' not in columns:
+        op.add_column('inventory_category', sa.Column('is_active', sa.Boolean(), nullable=True))
+        op.execute('UPDATE inventory_category SET is_active = TRUE WHERE is_active IS NULL')
+        op.alter_column('inventory_category', 'is_active', nullable=False, server_default=sa.true())
+    else:
+        op.alter_column('inventory_category', 'is_active', server_default=sa.true())
+
+    if 'is_global' not in columns:
+        op.add_column('inventory_category', sa.Column('is_global', sa.Boolean(), nullable=True))
+        op.execute('UPDATE inventory_category SET is_global = FALSE WHERE is_global IS NULL')
+        op.alter_column('inventory_category', 'is_global', nullable=False, server_default=sa.false())
+    else:
+        op.alter_column('inventory_category', 'is_global', server_default=sa.false())
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    try:
+        columns = {column['name'] for column in inspector.get_columns('inventory_category')}
+    except Exception:  # pragma: no cover - table missing
+        columns = set()
+
+    if 'is_global' in columns:
+        op.drop_column('inventory_category', 'is_global')
+    if 'is_active' in columns:
+        op.drop_column('inventory_category', 'is_active')
+    if 'sort_order' in columns:
+        op.drop_column('inventory_category', 'sort_order')

--- a/models_inventario.py
+++ b/models_inventario.py
@@ -12,6 +12,7 @@ class InventoryCategory(db.Model):
     parent_id = db.Column(db.Integer, db.ForeignKey('inventory_category.id'))
     sort_order = db.Column(db.Integer, nullable=False, default=0)
     is_active = db.Column(db.Boolean, nullable=False, default=True)
+    is_global = db.Column(db.Boolean, nullable=False, default=False, index=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Relaciones

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,5 @@ dependencies = [
     "matplotlib>=3.10.5",
     "pillow>=11.3.0",
     "mercadopago>=2.3.0",
+    "alembic>=1.14.0",
 ]

--- a/seed_inventory_categories.py
+++ b/seed_inventory_categories.py
@@ -20,537 +20,100 @@ from sqlalchemy import func
 
 DEFAULT_CATEGORY_TREE: List[Dict[str, object]] = [
     {
-        "nombre": "Materiales de Obra",
+        "nombre": "Materiales",
         "children": [
-            {
-                "nombre": "Cementos y aglomerantes",
-                "children": [
-                    {"nombre": "Cemento Portland"},
-                    {"nombre": "Cemento de alta resistencia"},
-                    {"nombre": "Cemento blanco"},
-                    {"nombre": "Cal aérea"},
-                    {"nombre": "Cal hidráulica"},
-                    {"nombre": "Yeso para construcción"},
-                    {"nombre": "Morteros premezclados"},
-                    {"nombre": "Adhesivos cementicios"},
-                ],
-            },
-            {
-                "nombre": "Áridos",
-                "children": [
-                    {"nombre": "Arena fina"},
-                    {"nombre": "Arena gruesa"},
-                    {"nombre": "Piedra partida"},
-                    {"nombre": "Ripio y estabilizado granular"},
-                    {"nombre": "Tosca y rellenos"},
-                    {"nombre": "Áridos livianos"},
-                ],
-            },
-            {
-                "nombre": "Mampostería",
-                "children": [
-                    {"nombre": "Ladrillos cerámicos comunes"},
-                    {"nombre": "Ladrillos huecos portantes"},
-                    {"nombre": "Bloques de hormigón"},
-                    {"nombre": "Bloques HCCA / retak"},
-                    {"nombre": "Paneles premoldeados"},
-                    {"nombre": "Placas EPS"},
-                ],
-            },
-            {
-                "nombre": "Acero y estructuras",
-                "children": [
-                    {"nombre": "Barras corrugadas"},
-                    {"nombre": "Mallas electrosoldadas"},
-                    {"nombre": "Perfiles laminados"},
-                    {"nombre": "Perfiles conformados"},
-                    {"nombre": "Accesorios y anclajes"},
-                ],
-            },
-            {
-                "nombre": "Impermeabilización y aislación",
-                "children": [
-                    {"nombre": "Membranas asfálticas"},
-                    {"nombre": "Membranas líquidas"},
-                    {"nombre": "Selladores poliuretánicos"},
-                    {"nombre": "Espumas de poliuretano"},
-                    {"nombre": "Barreras de vapor"},
-                    {"nombre": "Aislaciones termoacústicas"},
-                ],
-            },
-            {
-                "nombre": "Terminaciones y revestimientos",
-                "children": [
-                    {"nombre": "Revoques tradicionales"},
-                    {"nombre": "Revestimientos plásticos"},
-                    {"nombre": "Pinturas"},
-                    {"nombre": "Cerámicos y porcelanatos"},
-                    {"nombre": "Pastinas y fragües"},
-                    {"nombre": "Revestimientos vinílicos"},
-                ],
-            },
-            {
-                "nombre": "Maderas y derivados",
-                "children": [
-                    {"nombre": "Tablas y tirantes"},
-                    {"nombre": "Fenólicos"},
-                    {"nombre": "OSB"},
-                    {"nombre": "MDF"},
-                    {"nombre": "Decks y exteriores"},
-                    {"nombre": "Molduras y zócalos"},
-                ],
-            },
-            {
-                "nombre": "Plásticos y PVC",
-                "children": [
-                    {"nombre": "Caños de presión"},
-                    {"nombre": "Caños de desagüe"},
-                    {"nombre": "Accesorios hidráulicos"},
-                    {"nombre": "Planchas de polietileno"},
-                    {"nombre": "Geomembranas"},
-                ],
-            },
-            {
-                "nombre": "Vidrios y carpinterías",
-                "children": [
-                    {"nombre": "DVH y termopaneles"},
-                    {"nombre": "Marcos de aluminio"},
-                    {"nombre": "Marcos de PVC"},
-                    {"nombre": "Hojas y paños vidriados"},
-                    {"nombre": "Herrajes y cierres"},
-                    {"nombre": "Burletes y sellos"},
-                ],
-            },
+            {"nombre": "Cementos y aglomerantes"},
+            {"nombre": "Áridos"},
+            {"nombre": "Aceros y armaduras"},
+            {"nombre": "Aditivos y químicos para hormigón"},
+            {"nombre": "Maderas y tableros"},
+            {"nombre": "Plásticos y PVC"},
+            {"nombre": "Pinturas y revestimientos"},
+            {"nombre": "Impermeabilización y selladores"},
         ],
     },
     {
-        "nombre": "Instalaciones",
+        "nombre": "Sistemas de Encofrado",
         "children": [
-            {
-                "nombre": "Instalaciones eléctricas",
-                "children": [
-                    {"nombre": "Conductores de baja tensión"},
-                    {"nombre": "Bandejas y cañerías"},
-                    {"nombre": "Tableros y protecciones"},
-                    {"nombre": "Iluminación LED"},
-                    {"nombre": "Tomacorrientes y fichas"},
-                    {"nombre": "Sistemas de puesta a tierra"},
-                ],
-            },
-            {
-                "nombre": "Instalaciones sanitarias",
-                "children": [
-                    {"nombre": "Cañerías de agua fría/caliente"},
-                    {"nombre": "Cañerías de desagüe"},
-                    {"nombre": "Bombas y presurizadoras"},
-                    {"nombre": "Válvulas y llaves"},
-                    {"nombre": "Tanques y cisternas"},
-                ],
-            },
-            {
-                "nombre": "Instalaciones de gas",
-                "children": [
-                    {"nombre": "Cañerías de acero"},
-                    {"nombre": "Cañerías de cobre"},
-                    {"nombre": "Reguladores y medidores"},
-                    {"nombre": "Artefactos y quemadores"},
-                ],
-            },
-            {
-                "nombre": "Climatización",
-                "children": [
-                    {"nombre": "Equipos tipo split"},
-                    {"nombre": "Sistemas VRF"},
-                    {"nombre": "Conductos y difusores"},
-                    {"nombre": "Calefacción hidrónica"},
-                    {"nombre": "Ventiladores industriales"},
-                ],
-            },
-            {
-                "nombre": "Sistemas especiales",
-                "children": [
-                    {"nombre": "Domótica y BMS"},
-                    {"nombre": "Alarmas y control de acceso"},
-                    {"nombre": "CCTV"},
-                    {"nombre": "Redes de datos"},
-                    {"nombre": "Detección de incendio"},
-                    {"nombre": "Sonorización y megafonía"},
-                ],
-            },
+            {"nombre": "Vigas H20 (Peri/Hünnebeck compatibles)"},
+            {"nombre": "Puntales metálicos"},
+            {"nombre": "Barras/Tuercas DW (Dywidag)"},
+            {"nombre": "Paneles y chapas"},
+            {"nombre": "Accesorios de encofrado"},
+            {"nombre": "Tornapuntas y estabilizadores"},
         ],
     },
     {
-        "nombre": "Maquinarias y Equipos",
+        "nombre": "Herramientas",
         "children": [
-            {
-                "nombre": "Maquinaria pesada",
-                "children": [
-                    {"nombre": "Retroexcavadoras"},
-                    {"nombre": "Autoelevadores"},
-                    {"nombre": "Grúas y elevadores"},
-                    {"nombre": "Bombas de hormigón"},
-                    {"nombre": "Compresores industriales"},
-                ],
-            },
-            {
-                "nombre": "Herramientas eléctricas",
-                "children": [
-                    {"nombre": "Taladros y atornilladores"},
-                    {"nombre": "Amoladoras"},
-                    {"nombre": "Sierras eléctricas"},
-                    {"nombre": "Mezcladoras"},
-                    {"nombre": "Vibradores de hormigón"},
-                    {"nombre": "Martillos demoledores"},
-                ],
-            },
-            {
-                "nombre": "Herramientas manuales",
-                "children": [
-                    {"nombre": "Palas y picos"},
-                    {"nombre": "Mazas y martillos"},
-                    {"nombre": "Llaves y criques"},
-                    {"nombre": "Destornilladores"},
-                    {"nombre": "Niveles manuales"},
-                ],
-            },
-            {
-                "nombre": "Equipos de medición y control",
-                "children": [
-                    {"nombre": "Niveles láser"},
-                    {"nombre": "Estaciones totales"},
-                    {"nombre": "Medidores de humedad"},
-                    {"nombre": "Detectores de gas"},
-                    {"nombre": "Calibradores y micrómetros"},
-                ],
-            },
-            {
-                "nombre": "Vehículos y transporte interno",
-                "children": [
-                    {"nombre": "Camiones y utilitarios"},
-                    {"nombre": "Pick-ups"},
-                    {"nombre": "Carretillas"},
-                    {"nombre": "Zorras hidráulicas"},
-                    {"nombre": "Plataformas modulares"},
-                ],
-            },
+            {"nombre": "Manuales"},
+            {"nombre": "Eléctricas"},
+            {"nombre": "Medición y trazado"},
+            {"nombre": "Corte"},
+            {"nombre": "Fijación"},
+            {"nombre": "Neumáticas"},
         ],
     },
     {
-        "nombre": "Sistemas de Encofrado y Andamiaje",
+        "nombre": "Maquinarias",
         "children": [
-            {
-                "nombre": "Vigas H20",
-                "children": [
-                    {"nombre": "Vigas H20 estándar"},
-                    {"nombre": "Vigas H20 reforzadas"},
-                    {"nombre": "Vigas H20 accesorios"},
-                ],
-            },
-            {
-                "nombre": "Puntales metálicos",
-                "children": [
-                    {"nombre": "Puntales telescópicos"},
-                    {"nombre": "Puntales de alta carga"},
-                    {"nombre": "Puntales repuestos"},
-                ],
-            },
-            {
-                "nombre": "Barras DW y tuercas",
-                "children": [
-                    {"nombre": "Barras DW"},
-                    {"nombre": "Tuercas mariposa"},
-                    {"nombre": "Placas y arandelas"},
-                ],
-            },
-            {
-                "nombre": "Horquillas, trípodes y crucetas",
-                "children": [
-                    {"nombre": "Horquillas"},
-                    {"nombre": "Trípodes"},
-                    {"nombre": "Crucetas niveladoras"},
-                ],
-            },
-            {
-                "nombre": "Paneles fenólicos y metálicos",
-                "children": [
-                    {"nombre": "Paneles fenólicos"},
-                    {"nombre": "Paneles de aluminio"},
-                    {"nombre": "Paneles de acero"},
-                    {"nombre": "Revestimientos fenólicos"},
-                ],
-            },
-            {
-                "nombre": "Tensores, abrazaderas y pernos",
-                "children": [
-                    {"nombre": "Tensores"},
-                    {"nombre": "Abrazaderas"},
-                    {"nombre": "Pernos cónicos"},
-                ],
-            },
-            {
-                "nombre": "Andamios y accesorios",
-                "children": [
-                    {"nombre": "Andamios tubulares"},
-                    {"nombre": "Andamios multidireccionales"},
-                    {"nombre": "Plataformas colgantes"},
-                    {"nombre": "Ruedas y estabilizadores"},
-                ],
-            },
-            {
-                "nombre": "Sistemas trepantes y modulares",
-                "children": [
-                    {"nombre": "Sistemas trepantes"},
-                    {"nombre": "Encofrado deslizante"},
-                    {"nombre": "Encofrado modular"},
-                    {"nombre": "Accesorios trepantes"},
-                ],
-            },
-            {
-                "nombre": "Moldes para columnas y losas",
-                "children": [
-                    {"nombre": "Moldes para columnas circulares"},
-                    {"nombre": "Moldes para columnas rectangulares"},
-                    {"nombre": "Encofrado de losas"},
-                    {"nombre": "Accesorios de moldes"},
-                ],
-            },
+            {"nombre": "Andamios y plataformas"},
+            {"nombre": "Excavadoras"},
+            {"nombre": "Retroexcavadoras"},
+            {"nombre": "Autoelevadores"},
+            {"nombre": "Plumas y grúas"},
+            {"nombre": "Hormigoneras y bombeo"},
         ],
     },
     {
-        "nombre": "Seguridad e Higiene",
+        "nombre": "Seguridad",
         "children": [
-            {
-                "nombre": "Equipos de protección personal",
-                "children": [
-                    {"nombre": "Cascos"},
-                    {"nombre": "Chalecos"},
-                    {"nombre": "Guantes"},
-                    {"nombre": "Calzado"},
-                    {"nombre": "Arneses"},
-                ],
-            },
-            {
-                "nombre": "Señalización y barreras",
-                "children": [
-                    {"nombre": "Conos y vallas"},
-                    {"nombre": "Cintas perimetrales"},
-                    {"nombre": "Cartelería"},
-                ],
-            },
-            {
-                "nombre": "Extintores y contra incendio",
-                "children": [
-                    {"nombre": "Extintores"},
-                    {"nombre": "Gabinetes y mangueras"},
-                    {"nombre": "Detectores de humo"},
-                ],
-            },
-            {
-                "nombre": "Botiquines y primeros auxilios",
-                "children": [
-                    {"nombre": "Botiquines"},
-                    {"nombre": "Insumos de curación"},
-                    {"nombre": "Desfibriladores"},
-                ],
-            },
-            {
-                "nombre": "Equipos de rescate y evacuación",
-                "children": [
-                    {"nombre": "Camillas"},
-                    {"nombre": "Sistemas de descenso"},
-                    {"nombre": "Equipos de rescate vertical"},
-                ],
-            },
-            {
-                "nombre": "Kits de emergencia",
-                "children": [
-                    {"nombre": "Derrames"},
-                    {"nombre": "Derrames químicos"},
-                    {"nombre": "Control ambiental"},
-                ],
-            },
+            {"nombre": "Elementos de protección personal (EPP)"},
+            {"nombre": "Señalización"},
+            {"nombre": "Perímetro y cerramientos"},
+            {"nombre": "Trabajo en altura"},
+            {"nombre": "Control de acceso"},
         ],
     },
     {
-        "nombre": "Logística y Depósito",
+        "nombre": "Consumibles",
         "children": [
-            {
-                "nombre": "Pallets, cajas y contenedores",
-                "children": [
-                    {"nombre": "Pallets"},
-                    {"nombre": "Cajas plásticas"},
-                    {"nombre": "Contenedores metálicos"},
-                ],
-            },
-            {
-                "nombre": "Lonas y coberturas",
-                "children": [
-                    {"nombre": "Lonas pesadas"},
-                    {"nombre": "Cubiertas térmicas"},
-                    {"nombre": "Fundas impermeables"},
-                ],
-            },
-            {
-                "nombre": "Cintas y embalajes",
-                "children": [
-                    {"nombre": "Cintas de señalización"},
-                    {"nombre": "Stretch film"},
-                    {"nombre": "Fajas y zunchos"},
-                ],
-            },
-            {
-                "nombre": "Elementos de elevación y amarre",
-                "children": [
-                    {"nombre": "Eslingas"},
-                    {"nombre": "Grilletes"},
-                    {"nombre": "Tensores"},
-                ],
-            },
-            {
-                "nombre": "Control de accesos",
-                "children": [
-                    {"nombre": "Torniquetes"},
-                    {"nombre": "Molinetes"},
-                    {"nombre": "Credenciales"},
-                ],
-            },
-            {
-                "nombre": "Equipamiento de depósito",
-                "children": [
-                    {"nombre": "Estanterías y racks"},
-                    {"nombre": "Sistemas RFID"},
-                    {"nombre": "Equipos de etiquetado"},
-                ],
-            },
+            {"nombre": "Discos de corte y desbaste"},
+            {"nombre": "Brocas"},
+            {"nombre": "Tornillos"},
+            {"nombre": "Clavos y fijaciones"},
+            {"nombre": "Químicos y adhesivos"},
+            {"nombre": "Lubricantes y grasas"},
         ],
     },
     {
-        "nombre": "Administrativo y Oficina de Obra",
+        "nombre": "Logística y Depósitos",
         "children": [
-            {
-                "nombre": "Papelería y suministros",
-                "children": [
-                    {"nombre": "Papel e impresos"},
-                    {"nombre": "Artículos de escritura"},
-                    {"nombre": "Organización y archivo"},
-                ],
-            },
-            {
-                "nombre": "Electrónica y comunicaciones",
-                "children": [
-                    {"nombre": "Celulares"},
-                    {"nombre": "Tablets"},
-                    {"nombre": "Notebooks e impresoras"},
-                ],
-            },
-            {
-                "nombre": "Mobiliario y equipamiento",
-                "children": [
-                    {"nombre": "Puestos operativos"},
-                    {"nombre": "Sillas ergonómicas"},
-                    {"nombre": "Guardado y lockers"},
-                ],
-            },
-            {
-                "nombre": "Software y licencias",
-                "children": [
-                    {"nombre": "Gestión de obra"},
-                    {"nombre": "Diseño y BIM"},
-                    {"nombre": "Productividad y ofimática"},
-                ],
-            },
-            {
-                "nombre": "Uniformes y merchandising",
-                "children": [
-                    {"nombre": "Uniformes administrativos"},
-                    {"nombre": "Uniformes operativos"},
-                    {"nombre": "Merchandising corporativo"},
-                ],
-            },
+            {"nombre": "Transporte interno"},
+            {"nombre": "Equipamiento de depósito"},
+            {"nombre": "Embalajes y contenedores"},
+            {"nombre": "Sistemas de inventario"},
         ],
     },
     {
-        "nombre": "Consumibles e Insumos",
+        "nombre": "Oficina e IT",
         "children": [
-            {
-                "nombre": "Combustibles y lubricantes",
-                "children": [
-                    {"nombre": "Combustibles líquidos"},
-                    {"nombre": "Lubricantes"},
-                    {"nombre": "Grasas"},
-                ],
-            },
-            {
-                "nombre": "Insumos de limpieza",
-                "children": [
-                    {"nombre": "Detergentes"},
-                    {"nombre": "Desinfectantes"},
-                    {"nombre": "Elementos de limpieza"},
-                ],
-            },
-            {
-                "nombre": "Herramientas descartables",
-                "children": [
-                    {"nombre": "Cuchillas"},
-                    {"nombre": "Brochas y rodillos"},
-                    {"nombre": "Discos y lijas"},
-                ],
-            },
-            {
-                "nombre": "Baterías, lámparas y cables auxiliares",
-                "children": [
-                    {"nombre": "Baterías"},
-                    {"nombre": "Lámparas"},
-                    {"nombre": "Cables provisionales"},
-                ],
-            },
-            {
-                "nombre": "Gas envasado y fluidos",
-                "children": [
-                    {"nombre": "Gas envasado"},
-                    {"nombre": "Agua potable"},
-                    {"nombre": "Fluidos especiales"},
-                ],
-            },
-            {
-                "nombre": "Adhesivos y selladores puntuales",
-                "children": [
-                    {"nombre": "Adhesivos epoxi"},
-                    {"nombre": "Selladores químicos"},
-                    {"nombre": "Espumas temporales"},
-                ],
-            },
-            {
-                "nombre": "Repuestos varios",
-                "children": [
-                    {"nombre": "Cuchillas y insertos"},
-                    {"nombre": "Correas y transmisiones"},
-                    {"nombre": "Motores y bobinados"},
-                ],
-            },
+            {"nombre": "Computadoras y periféricos"},
+            {"nombre": "Redes y comunicación"},
+            {"nombre": "Impresión y planos"},
+            {"nombre": "Software y licencias"},
         ],
     },
     {
-        "nombre": "Categorías funcionales transversales",
+        "nombre": "Categorías transversales KPI",
         "children": [
-            {"nombre": "Obra base / núcleo"},
-            {"nombre": "Estructura"},
-            {"nombre": "Terminaciones"},
-            {"nombre": "Mantenimiento / post-venta"},
-            {"nombre": "Repuestos / reciclado"},
-            {
-                "nombre": "Desperdicio clasificado",
-                "children": [
-                    {"nombre": "Recuperable"},
-                    {"nombre": "No recuperable"},
-                    {"nombre": "Reutilizable"},
-                ],
-            },
-            {"nombre": "Reservas por proyecto / centro de costos"},
+            {"nombre": "Desperdicio"},
+            {"nombre": "Merma"},
+            {"nombre": "Reproceso"},
+            {"nombre": "Eficiencia operativa"},
         ],
     },
 ]
-
 
 def _get_or_create_category(
     *,
@@ -738,49 +301,70 @@ def main(argv: Optional[List[str]] = None) -> int:
     """Punto de entrada CLI."""
 
     parser = argparse.ArgumentParser(description='Seed de categorías de inventario')
-    parser.add_argument('--org', help='ID, slug, token o nombre de la organización destino')
-    parser.add_argument('--all', action='store_true', help='Sembrar todas las organizaciones')
+    parser.add_argument(
+        '--global',
+        dest='seed_global',
+        action='store_true',
+        help='Sembrar el catálogo global compartido',
+    )
+    parser.add_argument(
+        '--org',
+        dest='orgs',
+        action='append',
+        help='ID, slug, token o nombre de la organización destino (puede repetirse)',
+    )
     parser.add_argument('--quiet', action='store_true', help='Oculta el detalle por categoría')
 
     args = parser.parse_args(argv)
 
-    if args.org and args.all:
-        parser.error('Usa --org o --all, pero no ambos.')
-
     verbose = not args.quiet
+    org_identifiers = args.orgs or []
+    should_seed_global = args.seed_global or not org_identifiers
+    fallback_identifier = org_identifiers[0] if (args.seed_global and org_identifiers) else None
 
     from app import app
 
     with app.app_context():
-        if args.all or not args.org:
-            resultados = seed_inventory_categories_for_all(verbose=verbose)
-            if not resultados:
-                return 1
+        if should_seed_global:
+            fallback_org: Optional[Organizacion]
+            if fallback_identifier:
+                fallback_org = _resolve_organization(fallback_identifier)
+                if not fallback_org:
+                    print(f"❌ No se encontró la organización '{fallback_identifier}' para el catálogo global.")
+                    return 1
+            else:
+                fallback_org = Organizacion.query.order_by(Organizacion.id.asc()).first()
+                if not fallback_org:
+                    print('❌ No se encontraron organizaciones. Crea una antes de sembrar el catálogo global.')
+                    return 1
 
-            total_creadas = sum(stats.get('created', 0) for stats in resultados.values())
-            if not verbose:
-                for org_id, stats in resultados.items():
-                    organizacion = Organizacion.query.get(org_id)
-                    if organizacion:
-                        _print_seed_summary(organizacion.nombre, stats)
-            print(f"\n✅ Seed finalizado. Categorías nuevas: {total_creadas}")
-            return 0
+            stats = seed_inventory_categories_for_company(
+                fallback_org,
+                verbose=verbose,
+                mark_global=True,
+            )
+            db.session.commit()
 
-        organizacion = _resolve_organization(args.org)
-        if not organizacion:
-            print(f"❌ No se encontró la organización '{args.org}'.")
-            return 1
+            if verbose:
+                print('\n🌐 Catálogo global inicializado:')
+            _print_seed_summary(fallback_org.nombre if fallback_org else 'Global', stats)
 
-        stats = seed_inventory_categories_for_company(organizacion, verbose=verbose)
-        db.session.commit()
+        exit_code = 0
+        for identifier in org_identifiers:
+            organizacion = _resolve_organization(identifier)
+            if not organizacion:
+                print(f"❌ No se encontró la organización '{identifier}'.")
+                exit_code = 1
+                continue
 
-        if not verbose:
+            stats = seed_inventory_categories_for_company(organizacion, verbose=verbose)
+            db.session.commit()
+
+            if verbose:
+                print('\n📂 Resumen final:')
             _print_seed_summary(organizacion.nombre, stats)
-        else:
-            print("\n📂 Resumen final:")
-            _print_seed_summary(organizacion.nombre, stats)
 
-    return 0
+        return exit_code
 
 
 if __name__ == "__main__":

--- a/templates/base.html
+++ b/templates/base.html
@@ -93,7 +93,7 @@
                             {% if current_user.rol in ['administrador', 'tecnico'] and has_endpoint('inventario.uso_obra') %}
                             <li><a class="dropdown-item" href="{{ url_for('inventario.uso_obra') }}">Uso en Obra</a></li>
                             {% endif %}
-                            {% if current_user.rol == 'administrador' and has_endpoint('inventario.categorias') %}
+                            {% if (current_user.rol|default('')|lower == 'superadmin' or current_user.role|default('')|lower == 'superadmin') and has_endpoint('inventario.categorias') %}
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="{{ url_for('inventario.categorias') }}">Categorías</a></li>
                             {% endif %}

--- a/templates/inventario/crear.html
+++ b/templates/inventario/crear.html
@@ -132,7 +132,7 @@
                             <a href="{{ url_for('inventario.lista') }}" class="btn btn-secondary me-md-2">
                                 Cancelar
                             </a>
-                            <button type="submit" class="btn btn-primary" {{ 'disabled' if not categorias }}>
+                            <button type="submit" class="btn btn-primary" data-inventory-submit {{ 'disabled' if not categorias }}>
                                 <i class="fas fa-save me-1"></i>Crear Item
                             </button>
                         </div>
@@ -151,6 +151,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const nombreInput = document.getElementById('nombre');
     const categoriaSelect = document.getElementById('categoria_id');
     const categoryWarning = document.querySelector('[data-category-empty]');
+    const submitButton = document.querySelector('[data-inventory-submit]');
     const categoriesEndpoint = categoriaSelect ? categoriaSelect.dataset.categoriesEndpoint : null;
     const initialCategoryOptions = {{ category_options|default([], true)|tojson }};
 
@@ -163,6 +164,13 @@ document.addEventListener('DOMContentLoaded', function() {
         } else {
             categoryWarning.setAttribute('hidden', 'hidden');
         }
+    };
+
+    const toggleSubmitAvailability = (enabled) => {
+        if (!submitButton) {
+            return;
+        }
+        submitButton.disabled = !enabled;
     };
 
     const populateCategorySelect = (options, { preserveSelection = true } = {}) => {
@@ -218,13 +226,16 @@ document.addEventListener('DOMContentLoaded', function() {
             if (options.length) {
                 populateCategorySelect(options);
                 toggleCategoryWarning(false);
+                toggleSubmitAvailability(true);
             } else {
                 toggleCategoryWarning(true);
+                toggleSubmitAvailability(false);
             }
         } catch (error) {
             console.warn('No se pudieron cargar las categorías del inventario', error);
             if (!categoriaSelect || categoriaSelect.options.length <= 1) {
                 toggleCategoryWarning(true);
+                toggleSubmitAvailability(false);
             }
         }
     };
@@ -232,8 +243,12 @@ document.addEventListener('DOMContentLoaded', function() {
     if (initialCategoryOptions.length) {
         populateCategorySelect(initialCategoryOptions, { preserveSelection: false });
         toggleCategoryWarning(false);
+        toggleSubmitAvailability(true);
     } else if (categoriaSelect && categoriaSelect.options.length > 1) {
         toggleCategoryWarning(false);
+        toggleSubmitAvailability(true);
+    } else {
+        toggleSubmitAvailability(false);
     }
 
     refreshCategories();

--- a/templates/inventario/lista.html
+++ b/templates/inventario/lista.html
@@ -17,7 +17,7 @@
                         <i class="fas fa-plus me-1"></i>Nuevo Item
                     </a>
                     {% endif %}
-                    {% if current_user.rol == 'administrador' %}
+                    {% if current_user.rol|default('')|lower == 'superadmin' or current_user.role|default('')|lower == 'superadmin' %}
                     <a href="{{ url_for('inventario.categorias') }}" class="btn btn-outline-secondary ms-1">
                         <i class="fas fa-tags me-1"></i>Categorías
                     </a>

--- a/templates/inventario_new/item_form.html
+++ b/templates/inventario_new/item_form.html
@@ -115,7 +115,7 @@
                         
                         <div class="col-12">
                             <div class="d-flex gap-2">
-                                <button type="submit" class="btn btn-{% if item %}warning{% else %}success{% endif %}">
+                                <button type="submit" class="btn btn-{% if item %}warning{% else %}success{% endif %}" data-inventory-submit {{ '' if item or categorias else 'disabled' }}>
                                     <i class="fas fa-save me-2"></i>
                                     {% if item %}Actualizar Item{% else %}Crear Item{% endif %}
                                 </button>
@@ -142,8 +142,10 @@
 document.addEventListener('DOMContentLoaded', () => {
     const categoriaSelect = document.getElementById('categoria_id');
     const categoryWarning = document.querySelector('[data-category-empty]');
+    const submitButton = document.querySelector('[data-inventory-submit]');
     const categoriesEndpoint = categoriaSelect ? categoriaSelect.dataset.categoriesEndpoint : null;
     const initialCategoryOptions = {{ category_options|default([], true)|tojson }};
+    const isEditing = {{ 'true' if item else 'false' }};
 
     const toggleCategoryWarning = (show) => {
         if (!categoryWarning) {
@@ -154,6 +156,17 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             categoryWarning.setAttribute('hidden', 'hidden');
         }
+    };
+
+    const toggleSubmitAvailability = (enabled) => {
+        if (!submitButton) {
+            return;
+        }
+        if (isEditing) {
+            submitButton.disabled = false;
+            return;
+        }
+        submitButton.disabled = !enabled;
     };
 
     const populateCategorySelect = (options, { preserveSelection = true } = {}) => {
@@ -209,13 +222,16 @@ document.addEventListener('DOMContentLoaded', () => {
             if (options.length) {
                 populateCategorySelect(options);
                 toggleCategoryWarning(false);
+                toggleSubmitAvailability(true);
             } else {
                 toggleCategoryWarning(true);
+                toggleSubmitAvailability(false);
             }
         } catch (error) {
             console.warn('No se pudieron cargar las categorías del inventario', error);
             if (!categoriaSelect || categoriaSelect.options.length <= 1) {
                 toggleCategoryWarning(true);
+                toggleSubmitAvailability(false);
             }
         }
     };
@@ -223,8 +239,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (initialCategoryOptions.length) {
         populateCategorySelect(initialCategoryOptions, { preserveSelection: false });
         toggleCategoryWarning(false);
+        toggleSubmitAvailability(true);
     } else if (categoriaSelect && categoriaSelect.options.length > 1) {
         toggleCategoryWarning(false);
+        toggleSubmitAvailability(true);
+    } else {
+        toggleSubmitAvailability(false);
     }
 
     refreshCategories();


### PR DESCRIPTION
## Summary
- enforce PostgreSQL configuration with tuned pool settings and add Alembic scaffolding plus baseline migrations
- restrict inventory category management to superadmins, refresh the seeding tree/CLI, and auto-load categories from the API when empty
- enhance the inventory item form to fetch categories dynamically and add developer tooling for running Postgres locally

## Testing
- python -m compileall inventory_category_service.py seed_inventory_categories.py app.py

------
https://chatgpt.com/codex/tasks/task_e_68e5ac6cf2348322ad9617537396f7ca