### PR TITLE
Prevent automatic create_all execution and add inventory seed CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ DATABASE_URL=postgresql+psycopg2://obyra:postgres@localhost:5432/obyra_dev
 # Funcionalidades opcionales
 SHOW_IA_CALCULATOR_BUTTON=0
 ENABLE_REPORTS=1
+
+# Flags para inicialización controlada
+FLASK_SKIP_CREATE_ALL=0
+ALEMBIC_RUNNING=0

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from logging.config import fileConfig
 
 from alembic import context
@@ -16,6 +17,8 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 logger = logging.getLogger('alembic.env')
+
+os.environ.setdefault("ALEMBIC_RUNNING", "1")
 
 from app import app  # noqa: E402  pylint: disable=wrong-import-position
 

--- a/replit.md
+++ b/replit.md
@@ -12,6 +12,16 @@ flask db upgrade
 
 This command applies the lightweight migrations (incluyendo las columnas de estado y vigencia de presupuestos) contra tu base local antes de lanzar la app.
 
+> **Importante:** exportá `ALEMBIC_RUNNING=1` y `FLASK_SKIP_CREATE_ALL=1` cuando ejecutes migraciones o scripts que importan `app.py` sin levantar la aplicación. Esto evita que SQLAlchemy intente crear tablas fuera del flujo de Alembic.
+
+Para inicializar el catálogo global de inventario podés usar el nuevo comando CLI:
+
+```
+flask seed:inventario --global
+```
+
+También acepta múltiples `--org <identificador>` para sembrar organizaciones puntuales.
+
 ## User Preferences
 Preferred communication style: Simple, everyday language.
 


### PR DESCRIPTION
## Summary
- remove the implicit database bootstrap logic from the Flask app and add helpers to detect Alembic/skip flags
- expose a `flask seed:inventario` command to seed global and per-organization catalogues on demand
- document the new environment flags in `.env.example` and `replit.md`, and ensure Alembic sets `ALEMBIC_RUNNING`

## Testing
- not run (Alembic/Flask CLIs are not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5b7e73d0c83228e30c5e975b54758