### PR TITLE
Ajustes UI dashboards: menú de roles + KPIs útiles + rediseño responsive

### DIFF
--- a/services/dashboard_service.py
+++ b/services/dashboard_service.py
@@ -100,13 +100,18 @@ def resumen_financiero(resumenes) -> dict:
     tot_pres = sum(r['presupuesto'] for r in resumenes)
     tot_costo = sum(r['costo_real'] for r in resumenes)
     margen = tot_pres - tot_costo
+    atrasadas = sum(1 for r in resumenes if r.get('estado_operativo') == 'ATRASADA')
     return {
         'presupuesto_total': tot_pres,
         'gastado_total': tot_costo,
+        # margen/margen_pct: se conservan por compatibilidad, pero NO son KPI de
+        # portada. Cuando la ejecucion es baja, margen_pct ~= 100% e informa poco
+        # (es casi el complemento de ejecucion_pct). Portada usa ejecucion + atrasadas.
         'margen': margen,
         'margen_pct': round(margen / tot_pres * 100, 1) if tot_pres > 0 else 0.0,
         'ejecucion_pct': round(tot_costo / tot_pres * 100, 1) if tot_pres > 0 else 0.0,
         'cantidad_obras': len(resumenes),
+        'obras_atrasadas': atrasadas,
     }
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -258,6 +258,11 @@
                             <li><a class="dropdown-item" href="{{ url_for('equipos.usuarios_listar') }}">
                                 <i class="fas fa-users-cog me-2"></i>Gestión de Usuarios
                             </a></li>
+                            {% if current_user.es_admin() and has_endpoint('equipos.roles_admin') %}
+                            <li><a class="dropdown-item" href="{{ url_for('equipos.roles_admin') }}">
+                                <i class="fas fa-user-shield me-2"></i>Roles y Permisos
+                            </a></li>
+                            {% endif %}
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="{{ url_for('equipos.rendimiento') }}">Rendimiento</a></li>
                             {% endif %}

--- a/templates/dashboards/_dash_macros.html
+++ b/templates/dashboards/_dash_macros.html
@@ -1,0 +1,23 @@
+{# Macros compartidos por los 4 dashboards #}
+
+{# Formatea montos grandes de forma legible: $16.3B, $28.7M, $4.2K, $340 #}
+{% macro money(v) -%}
+{%- set n = (v or 0) | float -%}
+{%- if n < 0 -%}{% set sign = '-' %}{% set n = -n %}{%- else -%}{% set sign = '' %}{%- endif -%}
+{%- if n >= 1000000000 -%}{{ sign }}${{ '%.1f'|format(n/1000000000) }}B
+{%- elif n >= 1000000 -%}{{ sign }}${{ '%.1f'|format(n/1000000) }}M
+{%- elif n >= 1000 -%}{{ sign }}${{ '%.1f'|format(n/1000) }}K
+{%- else -%}{{ sign }}${{ '%.0f'|format(n) }}
+{%- endif -%}
+{%- endmacro %}
+
+{% set _ESTADO_COLOR = {
+  'FINALIZADA':'secondary', 'PARADA':'dark', 'CRITICA':'danger',
+  'ATRASADA':'warning', 'EN_CURSO':'success', 'CANCELADA':'secondary'
+} %}
+
+{% macro estado_color(eo) -%}{{ _ESTADO_COLOR.get(eo, 'secondary') }}{%- endmacro %}
+
+{% macro estado_badge(eo) -%}
+<span class="badge rounded-pill bg-{{ _ESTADO_COLOR.get(eo, 'secondary') }}-subtle text-{{ _ESTADO_COLOR.get(eo, 'secondary') }}-emphasis border border-{{ _ESTADO_COLOR.get(eo, 'secondary') }}-subtle">{{ eo|replace('_',' ')|title }}</span>
+{%- endmacro %}

--- a/templates/dashboards/_dash_styles.html
+++ b/templates/dashboards/_dash_styles.html
@@ -1,0 +1,66 @@
+<style>
+  .dash {
+    --dash-shadow: 0 1px 2px rgba(16,24,40,.05), 0 4px 16px rgba(16,24,40,.06);
+    --dash-shadow-hover: 0 2px 6px rgba(16,24,40,.08), 0 10px 28px rgba(16,24,40,.10);
+    --dash-muted: #667085;
+  }
+  .dash h3 { font-weight: 700; letter-spacing: -.02em; }
+  .dash .card {
+    border: 0; border-radius: 16px; box-shadow: var(--dash-shadow);
+    transition: box-shadow .18s ease, transform .18s ease;
+  }
+  .dash .card-header {
+    background: transparent; border-bottom: 1px solid rgba(16,24,40,.07);
+    font-weight: 600; padding: .9rem 1.1rem;
+  }
+  .dash .card-body { padding: 1.1rem; }
+
+  /* KPI cards */
+  .kpi .card-body { display: flex; align-items: center; gap: .9rem; }
+  .kpi:hover { transform: translateY(-2px); box-shadow: var(--dash-shadow-hover); }
+  .kpi-icon {
+    flex: 0 0 auto; width: 46px; height: 46px; border-radius: 12px;
+    display: flex; align-items: center; justify-content: center; font-size: 1.15rem;
+  }
+  .kpi-body { flex: 1 1 auto; min-width: 0; }
+  .kpi-label {
+    font-size: .7rem; text-transform: uppercase; letter-spacing: .05em;
+    color: var(--dash-muted); font-weight: 700; margin-bottom: 2px;
+  }
+  .kpi-value {
+    font-size: clamp(1.35rem, 4.2vw, 1.85rem); font-weight: 750; line-height: 1.05;
+    letter-spacing: -.02em; font-variant-numeric: tabular-nums;
+  }
+  .kpi-sub { font-size: .78rem; color: var(--dash-muted); margin-top: 1px; }
+
+  /* Tablas */
+  .dash table { --bs-table-border-color: rgba(16,24,40,.06); }
+  .dash thead th {
+    font-size: .72rem; text-transform: uppercase; letter-spacing: .04em;
+    color: var(--dash-muted); font-weight: 700; border-bottom-width: 1px;
+  }
+  .dash td, .dash th { padding-top: .7rem; padding-bottom: .7rem; }
+  .dash .num { font-variant-numeric: tabular-nums; }
+  .obra-name { font-weight: 650; text-decoration: none; }
+  .obra-name:hover { text-decoration: underline; }
+
+  /* Progreso */
+  .dash .progress { height: 9px; border-radius: 8px; background: #eef1f5; }
+  .dash .progress-bar { border-radius: 8px; }
+  .progress-wrap { min-width: 110px; }
+
+  /* Alertas: que NO se corten en movil */
+  .dash .list-group-item { border: 0; border-bottom: 1px solid rgba(16,24,40,.05); }
+  .dash .list-group-item:last-child { border-bottom: 0; }
+  .alert-title { font-weight: 650; font-size: .85rem; word-break: break-word; }
+  .alert-detail { font-size: .8rem; color: var(--dash-muted); word-break: break-word; }
+  .alert-min0 { min-width: 0; }
+
+  /* Responsive: en movil las cards se apilan y las tablas scrollean */
+  .dash .table-responsive { -webkit-overflow-scrolling: touch; }
+  @media (max-width: 575.98px) {
+    .dash .card-body { padding: .9rem; }
+    .kpi-icon { width: 40px; height: 40px; font-size: 1rem; }
+    .dash table { min-width: 460px; }  /* fuerza scroll horizontal, sin cortar columnas */
+  }
+</style>

--- a/templates/dashboards/admin.html
+++ b/templates/dashboards/admin.html
@@ -1,123 +1,112 @@
 {% extends "base.html" %}
-{% block title %}Dashboard Admin | OBYRA{% endblock %}
-
-{% set BADGE = {
-  'FINALIZADA': 'secondary', 'PARADA': 'dark', 'CRITICA': 'danger',
-  'ATRASADA': 'warning', 'EN_CURSO': 'success', 'CANCELADA': 'secondary'
-} %}
+{% from 'dashboards/_dash_macros.html' import money, estado_badge, estado_color %}
+{% block title %}Dashboard | OBYRA{% endblock %}
+{% block extra_head %}{% include 'dashboards/_dash_styles.html' %}{% endblock %}
 
 {% block content %}
-<div class="container-fluid py-4">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <div>
-      <h3 class="mb-0"><i class="fas fa-gauge-high me-2 text-primary"></i>Dashboard</h3>
-      <small class="text-muted">Vista general de la organización</small>
-    </div>
+<div class="container-fluid py-4 dash">
+  <div class="mb-4">
+    <h3 class="mb-0"><i class="fas fa-gauge-high me-2 text-primary"></i>Dashboard</h3>
+    <span class="text-muted small">Vista general de la organización</span>
   </div>
 
-  {# ---------- Resumen financiero ---------- #}
+  {# ---------- KPIs de portada ---------- #}
   <div class="row g-3 mb-4">
-    <div class="col-6 col-lg-3">
-      <div class="card h-100 shadow-sm border-0">
-        <div class="card-body">
-          <small class="text-muted text-uppercase">Presupuesto total</small>
-          <h4 class="mb-0">${{ "{:,.0f}".format(financiero.presupuesto_total) }}</h4>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon bg-primary-subtle text-primary"><i class="fas fa-wallet"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Presupuesto total</div>
+          <div class="kpi-value">{{ money(financiero.presupuesto_total) }}</div>
+          <div class="kpi-sub">{{ financiero.cantidad_obras }} obra(s) activa(s)</div>
         </div>
-      </div>
+      </div></div>
     </div>
-    <div class="col-6 col-lg-3">
-      <div class="card h-100 shadow-sm border-0">
-        <div class="card-body">
-          <small class="text-muted text-uppercase">Gastado (real)</small>
-          <h4 class="mb-0">${{ "{:,.0f}".format(financiero.gastado_total) }}</h4>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon bg-info-subtle text-info"><i class="fas fa-money-bill-wave"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Gastado (real)</div>
+          <div class="kpi-value">{{ money(financiero.gastado_total) }}</div>
+          <div class="kpi-sub">costo recalculado</div>
         </div>
-      </div>
+      </div></div>
     </div>
-    <div class="col-6 col-lg-3">
-      <div class="card h-100 shadow-sm border-0">
-        <div class="card-body">
-          <small class="text-muted text-uppercase">Margen</small>
-          <h4 class="mb-0 {{ 'text-danger' if financiero.margen < 0 else 'text-success' }}">
-            ${{ "{:,.0f}".format(financiero.margen) }}
-            <small class="fs-6">({{ financiero.margen_pct }}%)</small>
-          </h4>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon bg-success-subtle text-success"><i class="fas fa-gauge"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Ejecución</div>
+          <div class="kpi-value">{{ financiero.ejecucion_pct }}%</div>
+          <div class="progress mt-2" role="progressbar" aria-valuenow="{{ financiero.ejecucion_pct }}" aria-valuemin="0" aria-valuemax="100">
+            <div class="progress-bar bg-success" style="width: {{ [financiero.ejecucion_pct, 100]|min }}%"></div>
+          </div>
         </div>
-      </div>
+      </div></div>
     </div>
-    <div class="col-6 col-lg-3">
-      <div class="card h-100 shadow-sm border-0">
-        <div class="card-body">
-          <small class="text-muted text-uppercase">Ejecución</small>
-          <h4 class="mb-0">{{ financiero.ejecucion_pct }}%</h4>
-          <small class="text-muted">{{ financiero.cantidad_obras }} obra(s) activa(s)</small>
+    <div class="col-12 col-sm-6 col-lg-3">
+      {% set atras = financiero.obras_atrasadas %}
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon {{ 'bg-danger-subtle text-danger' if atras else 'bg-secondary-subtle text-secondary' }}"><i class="fas fa-triangle-exclamation"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Obras atrasadas</div>
+          <div class="kpi-value {{ 'text-danger' if atras }}">{{ atras }}</div>
+          <div class="kpi-sub">{{ 'requieren atención' if atras else 'todo en fecha' }}</div>
         </div>
-      </div>
+      </div></div>
     </div>
   </div>
 
   <div class="row g-4">
-    {# ---------- Alertas críticas ---------- #}
-    <div class="col-lg-4">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-bell me-2 text-danger"></i>Alertas críticas</strong>
-        </div>
+    {# ---------- Alertas ---------- #}
+    <div class="col-12 col-lg-4">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-bell me-2 text-danger"></i>Alertas críticas</div>
         <div class="list-group list-group-flush">
           {% for a in alertas %}
           <a href="{{ a.url or '#' }}" class="list-group-item list-group-item-action">
             <div class="d-flex align-items-start gap-2">
               <i class="fas {{ a.icono or 'fa-circle-exclamation' }} text-{{ a.color or 'secondary' }} mt-1"></i>
-              <div>
-                <div class="fw-semibold small">{{ a.titulo }}</div>
-                <div class="text-muted small">{{ a.detalle }}</div>
+              <div class="alert-min0">
+                <div class="alert-title">{{ a.titulo }}</div>
+                <div class="alert-detail">{{ a.detalle }}</div>
               </div>
             </div>
           </a>
           {% else %}
-          <div class="list-group-item text-muted small text-center py-4">
-            <i class="fas fa-check-circle text-success me-1"></i> Sin alertas
-          </div>
+          <div class="list-group-item text-center text-muted py-4"><i class="fas fa-check-circle text-success me-1"></i>Sin alertas</div>
           {% endfor %}
         </div>
       </div>
     </div>
 
     {# ---------- Obras activas ---------- #}
-    <div class="col-lg-8">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-building me-2 text-primary"></i>Obras activas</strong>
-        </div>
+    <div class="col-12 col-lg-8">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-building me-2 text-primary"></i>Obras activas</div>
         <div class="table-responsive">
-          <table class="table table-sm align-middle mb-0">
-            <thead class="table-light">
-              <tr>
-                <th>Obra</th>
-                <th class="text-end">Presupuesto</th>
-                <th class="text-end">Costo real</th>
-                <th style="min-width:120px">Avance</th>
-                <th>Estado</th>
-              </tr>
-            </thead>
+          <table class="table align-middle mb-0">
+            <thead><tr>
+              <th>Obra</th><th class="text-end">Presupuesto</th><th class="text-end">Costo real</th>
+              <th class="progress-wrap">Avance</th><th>Estado</th>
+            </tr></thead>
             <tbody>
               {% for o in obras %}
               <tr>
                 <td>
-                  <a href="{{ url_for('obras.detalle', id=o.id) }}" class="text-decoration-none fw-semibold">{{ o.nombre }}</a>
+                  <a href="{{ url_for('obras.detalle', id=o.id) }}" class="obra-name">{{ o.nombre }}</a>
                   <div class="text-muted small">{{ o.cliente }}</div>
                 </td>
-                <td class="text-end">${{ "{:,.0f}".format(o.presupuesto) }}</td>
-                <td class="text-end">
-                  ${{ "{:,.0f}".format(o.costo_real) }}
-                  <div class="small {{ 'text-danger' if o.consumo_pct > 100 else 'text-muted' }}">{{ o.consumo_pct }}%</div>
+                <td class="text-end num">{{ money(o.presupuesto) }}</td>
+                <td class="text-end num">
+                  {{ money(o.costo_real) }}
+                  <div class="small {{ 'text-danger' if o.consumo_pct > 100 else 'text-muted' }}">{{ o.consumo_pct }}% del ppto.</div>
                 </td>
-                <td>
-                  <div class="progress" style="height:6px">
-                    <div class="progress-bar bg-{{ BADGE.get(o.estado_operativo, 'primary') }}" style="width: {{ o.avance }}%"></div>
-                  </div>
-                  <small class="text-muted">{{ o.avance }}%</small>
+                <td class="progress-wrap">
+                  <div class="progress"><div class="progress-bar bg-{{ estado_color(o.estado_operativo) }}" style="width: {{ o.avance }}%"></div></div>
+                  <span class="text-muted small num">{{ o.avance }}%</span>
                 </td>
-                <td><span class="badge bg-{{ BADGE.get(o.estado_operativo, 'secondary') }}">{{ o.estado_operativo }}</span></td>
+                <td>{{ estado_badge(o.estado_operativo) }}</td>
               </tr>
               {% else %}
               <tr><td colspan="5" class="text-center text-muted py-4">No hay obras activas</td></tr>
@@ -132,28 +121,21 @@
   {# ---------- Entregas próximas ---------- #}
   <div class="row g-4 mt-1">
     <div class="col-12">
-      <div class="card shadow-sm border-0">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-truck me-2 text-info"></i>Entregas próximas</strong>
-        </div>
+      <div class="card">
+        <div class="card-header"><i class="fas fa-truck me-2 text-info"></i>Entregas próximas</div>
         <div class="table-responsive">
-          <table class="table table-sm align-middle mb-0">
-            <thead class="table-light">
-              <tr><th>OC</th><th>Proveedor</th><th>Obra</th><th>Fecha</th><th>Estado</th></tr>
-            </thead>
+          <table class="table align-middle mb-0">
+            <thead><tr><th>OC</th><th>Proveedor</th><th>Obra</th><th>Fecha</th><th>Estado</th></tr></thead>
             <tbody>
               {% for e in entregas %}
               <tr>
-                <td><a href="{{ e.url }}" class="text-decoration-none">{{ e.numero }}</a></td>
+                <td><a href="{{ e.url }}" class="obra-name">{{ e.numero }}</a></td>
                 <td>{{ e.proveedor }}</td>
                 <td>{{ e.obra }}</td>
-                <td>{{ e.fecha }}</td>
+                <td class="num">{{ e.fecha }}</td>
                 <td>
-                  {% if e.vencida %}
-                  <span class="badge bg-danger">Vencida ({{ -e.dias }}d)</span>
-                  {% else %}
-                  <span class="badge bg-info text-dark">En {{ e.dias }}d</span>
-                  {% endif %}
+                  {% if e.vencida %}<span class="badge bg-danger">Vencida ({{ -e.dias }}d)</span>
+                  {% else %}<span class="badge bg-info-subtle text-info-emphasis border border-info-subtle">En {{ e.dias }}d</span>{% endif %}
                 </td>
               </tr>
               {% else %}

--- a/templates/dashboards/operario.html
+++ b/templates/dashboards/operario.html
@@ -1,81 +1,66 @@
 {% extends "base.html" %}
 {% block title %}Mis tareas | OBYRA{% endblock %}
+{% block extra_head %}{% include 'dashboards/_dash_styles.html' %}{% endblock %}
 
 {% block content %}
-<div class="container-fluid py-4">
+<div class="container-fluid py-4 dash">
   <div class="mb-4">
-    <h3 class="mb-0"><i class="fas fa-list-check me-2 text-primary"></i>Mis tareas</h3>
-    <small class="text-muted">Tareas pendientes y en progreso</small>
+    <h3 class="mb-0"><i class="fas fa-clipboard-list me-2 text-primary"></i>Mis tareas</h3>
+    <span class="text-muted small">Tareas asignadas y material recibido</span>
   </div>
 
   <div class="row g-4">
     {# ---------- Mis tareas ---------- #}
-    <div class="col-lg-7">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-clipboard-list me-2 text-primary"></i>Tareas asignadas</strong>
+    <div class="col-12 col-lg-7">
+      <div class="card h-100">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span><i class="fas fa-list-check me-2 text-primary"></i>Tareas asignadas</span>
+          <span class="badge bg-primary-subtle text-primary-emphasis">{{ tareas|length }}</span>
         </div>
         <div class="list-group list-group-flush">
           {% for t in tareas %}
-          <a href="{{ url_for('obras.mis_tareas_detalle', tarea_id=t.id) }}"
-             class="list-group-item list-group-item-action">
-            <div class="d-flex justify-content-between align-items-start">
-              <div>
-                <div class="fw-semibold">{{ t.nombre }}</div>
-                <div class="text-muted small"><i class="fas fa-building me-1"></i>{{ t.obra }}</div>
-              </div>
-              <div class="text-end">
-                {% if t.estado == 'en_curso' %}
-                <span class="badge bg-primary">En progreso</span>
-                {% else %}
-                <span class="badge bg-secondary">Pendiente</span>
-                {% endif %}
+          <a href="{{ url_for('obras.mis_tareas_detalle', tarea_id=t.id) }}" class="list-group-item list-group-item-action">
+            <div class="d-flex justify-content-between align-items-start gap-2">
+              <div class="alert-min0">
+                <div class="alert-title">{{ t.nombre }}</div>
+                <div class="alert-detail"><i class="fas fa-building me-1"></i>{{ t.obra }}</div>
                 {% if t.atrasada %}
-                <div class="small text-danger mt-1"><i class="fas fa-clock me-1"></i>Vencía {{ t.fecha_fin_plan }}</div>
+                <div class="small text-danger mt-1"><i class="fas fa-triangle-exclamation me-1"></i>Atrasada · venció {{ t.fecha_fin_plan }}</div>
                 {% elif t.fecha_fin_plan %}
-                <div class="small text-muted mt-1">Vence {{ t.fecha_fin_plan }}</div>
+                <div class="small text-muted mt-1"><i class="fas fa-calendar me-1"></i>Vence {{ t.fecha_fin_plan }}</div>
                 {% endif %}
               </div>
+              <span class="badge {{ 'bg-primary-subtle text-primary-emphasis' if t.estado == 'en_curso' else 'bg-secondary-subtle text-secondary-emphasis' }} flex-shrink-0">
+                {{ 'En progreso' if t.estado == 'en_curso' else 'Pendiente' }}
+              </span>
             </div>
           </a>
           {% else %}
-          <div class="list-group-item text-muted text-center py-5">
-            <i class="fas fa-mug-hot fa-2x mb-2 d-block text-success"></i>
-            No tenés tareas pendientes
+          <div class="list-group-item text-center text-muted py-5">
+            <i class="fas fa-mug-hot fa-lg mb-2 d-block text-success"></i>No tenés tareas pendientes
           </div>
           {% endfor %}
         </div>
       </div>
     </div>
 
-    {# ---------- Material para mis tareas ---------- #}
-    <div class="col-lg-5">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-truck-ramp-box me-2 text-info"></i>Material recibido</strong>
-        </div>
+    {# ---------- Material recibido ---------- #}
+    <div class="col-12 col-lg-5">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-truck-ramp-box me-2 text-info"></i>Material recibido</div>
         <div class="list-group list-group-flush">
           {% for m in material %}
           <div class="list-group-item">
-            <div class="d-flex justify-content-between">
-              <div>
-                <div class="fw-semibold small">Remito {{ m.numero }}</div>
-                <div class="text-muted small">{{ m.proveedor }}</div>
+            <div class="d-flex justify-content-between align-items-start gap-2">
+              <div class="alert-min0">
+                <div class="alert-title">{{ m.proveedor }}</div>
+                <div class="alert-detail">Remito {{ m.numero }} · {{ m.fecha }}</div>
               </div>
-              <div class="text-end">
-                <div class="small">{{ m.fecha }}</div>
-                {% if m.estado == 'recibido' %}
-                <span class="badge bg-success">Recibido</span>
-                {% elif m.estado == 'con_observaciones' %}
-                <span class="badge bg-warning text-dark">Con obs.</span>
-                {% else %}
-                <span class="badge bg-danger">{{ m.estado }}</span>
-                {% endif %}
-              </div>
+              <span class="badge bg-success-subtle text-success-emphasis flex-shrink-0">{{ m.estado }}</span>
             </div>
           </div>
           {% else %}
-          <div class="list-group-item text-muted small text-center py-4">Sin material reciente</div>
+          <div class="list-group-item text-center text-muted py-4">Sin material reciente</div>
           {% endfor %}
         </div>
       </div>

--- a/templates/dashboards/pm.html
+++ b/templates/dashboards/pm.html
@@ -1,82 +1,112 @@
 {% extends "base.html" %}
-{% block title %}Dashboard PM | OBYRA{% endblock %}
-
-{% set BADGE = {
-  'FINALIZADA': 'secondary', 'PARADA': 'dark', 'CRITICA': 'danger',
-  'ATRASADA': 'warning', 'EN_CURSO': 'success', 'CANCELADA': 'secondary'
-} %}
+{% from 'dashboards/_dash_macros.html' import money, estado_badge, estado_color %}
+{% block title %}Mis proyectos | OBYRA{% endblock %}
+{% block extra_head %}{% include 'dashboards/_dash_styles.html' %}{% endblock %}
 
 {% block content %}
-<div class="container-fluid py-4">
+<div class="container-fluid py-4 dash">
   <div class="mb-4">
     <h3 class="mb-0"><i class="fas fa-diagram-project me-2 text-primary"></i>Mis proyectos</h3>
-    <small class="text-muted">Obras que gestionás · {{ financiero.cantidad_obras }} activa(s)</small>
+    <span class="text-muted small">Obras que gestionás · {{ financiero.cantidad_obras }} activa(s)</span>
+  </div>
+
+  {# ---------- KPIs ---------- #}
+  <div class="row g-3 mb-4">
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon bg-primary-subtle text-primary"><i class="fas fa-wallet"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Presupuesto</div>
+          <div class="kpi-value">{{ money(financiero.presupuesto_total) }}</div>
+          <div class="kpi-sub">de mis obras</div>
+        </div>
+      </div></div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon bg-info-subtle text-info"><i class="fas fa-money-bill-wave"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Gastado (real)</div>
+          <div class="kpi-value">{{ money(financiero.gastado_total) }}</div>
+          <div class="kpi-sub">costo recalculado</div>
+        </div>
+      </div></div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon bg-success-subtle text-success"><i class="fas fa-gauge"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Ejecución</div>
+          <div class="kpi-value">{{ financiero.ejecucion_pct }}%</div>
+          <div class="progress mt-2" role="progressbar" aria-valuenow="{{ financiero.ejecucion_pct }}" aria-valuemin="0" aria-valuemax="100">
+            <div class="progress-bar bg-success" style="width: {{ [financiero.ejecucion_pct, 100]|min }}%"></div>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      {% set atras = financiero.obras_atrasadas %}
+      <div class="card h-100 kpi"><div class="card-body">
+        <div class="kpi-icon {{ 'bg-danger-subtle text-danger' if atras else 'bg-secondary-subtle text-secondary' }}"><i class="fas fa-triangle-exclamation"></i></div>
+        <div class="kpi-body">
+          <div class="kpi-label">Atrasadas</div>
+          <div class="kpi-value {{ 'text-danger' if atras }}">{{ atras }}</div>
+          <div class="kpi-sub">{{ 'requieren atención' if atras else 'todo en fecha' }}</div>
+        </div>
+      </div></div>
+    </div>
   </div>
 
   <div class="row g-4">
     {# ---------- Alertas de mis obras ---------- #}
-    <div class="col-lg-4">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-bell me-2 text-danger"></i>Alertas de mis obras</strong>
-        </div>
+    <div class="col-12 col-lg-4">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-bell me-2 text-danger"></i>Alertas de mis obras</div>
         <div class="list-group list-group-flush">
           {% for a in alertas %}
           <a href="{{ a.url or '#' }}" class="list-group-item list-group-item-action">
             <div class="d-flex align-items-start gap-2">
               <i class="fas {{ a.icono or 'fa-circle-exclamation' }} text-{{ a.color or 'secondary' }} mt-1"></i>
-              <div>
-                <div class="fw-semibold small">{{ a.titulo }}</div>
-                <div class="text-muted small">{{ a.detalle }}</div>
+              <div class="alert-min0">
+                <div class="alert-title">{{ a.titulo }}</div>
+                <div class="alert-detail">{{ a.detalle }}</div>
               </div>
             </div>
           </a>
           {% else %}
-          <div class="list-group-item text-muted small text-center py-4">
-            <i class="fas fa-check-circle text-success me-1"></i> Todo en orden
-          </div>
+          <div class="list-group-item text-center text-muted py-4"><i class="fas fa-check-circle text-success me-1"></i>Todo en orden</div>
           {% endfor %}
         </div>
       </div>
     </div>
 
     {# ---------- Obras que gestiona ---------- #}
-    <div class="col-lg-8">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0 d-flex justify-content-between">
-          <strong><i class="fas fa-building me-2 text-primary"></i>Obras que gestiono</strong>
-          <span class="text-muted small">Margen total: ${{ "{:,.0f}".format(financiero.margen) }} ({{ financiero.margen_pct }}%)</span>
-        </div>
+    <div class="col-12 col-lg-8">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-building me-2 text-primary"></i>Obras que gestiono</div>
         <div class="table-responsive">
-          <table class="table table-sm align-middle mb-0">
-            <thead class="table-light">
-              <tr>
-                <th>Obra</th>
-                <th class="text-end">Presupuesto</th>
-                <th class="text-end">Costo real</th>
-                <th style="min-width:120px">Avance</th>
-                <th>Estado</th>
-              </tr>
-            </thead>
+          <table class="table align-middle mb-0">
+            <thead><tr>
+              <th>Obra</th><th class="text-end">Presupuesto</th><th class="text-end">Costo real</th>
+              <th class="progress-wrap">Avance</th><th>Estado</th>
+            </tr></thead>
             <tbody>
               {% for o in obras %}
               <tr>
                 <td>
-                  <a href="{{ url_for('obras.detalle', id=o.id) }}" class="text-decoration-none fw-semibold">{{ o.nombre }}</a>
+                  <a href="{{ url_for('obras.detalle', id=o.id) }}" class="obra-name">{{ o.nombre }}</a>
                   <div class="text-muted small">{{ o.cliente }}</div>
                 </td>
-                <td class="text-end">${{ "{:,.0f}".format(o.presupuesto) }}</td>
-                <td class="text-end">
-                  ${{ "{:,.0f}".format(o.costo_real) }}
-                  <div class="small {{ 'text-danger' if o.consumo_pct > 100 else 'text-muted' }}">{{ o.consumo_pct }}%</div>
+                <td class="text-end num">{{ money(o.presupuesto) }}</td>
+                <td class="text-end num">
+                  {{ money(o.costo_real) }}
+                  <div class="small {{ 'text-danger' if o.consumo_pct > 100 else 'text-muted' }}">{{ o.consumo_pct }}% del ppto.</div>
                 </td>
-                <td>
-                  <div class="progress" style="height:6px">
-                    <div class="progress-bar bg-{{ BADGE.get(o.estado_operativo, 'primary') }}" style="width: {{ o.avance }}%"></div>
-                  </div>
-                  <small class="text-muted">{{ o.avance }}%</small>
+                <td class="progress-wrap">
+                  <div class="progress"><div class="progress-bar bg-{{ estado_color(o.estado_operativo) }}" style="width: {{ o.avance }}%"></div></div>
+                  <span class="text-muted small num">{{ o.avance }}%</span>
                 </td>
-                <td><span class="badge bg-{{ BADGE.get(o.estado_operativo, 'secondary') }}">{{ o.estado_operativo }}</span></td>
+                <td>{{ estado_badge(o.estado_operativo) }}</td>
               </tr>
               {% else %}
               <tr><td colspan="5" class="text-center text-muted py-4">No gestionás obras activas</td></tr>
@@ -89,27 +119,20 @@
   </div>
 
   <div class="row g-4 mt-1">
-    {# ---------- Entregas de mis obras ---------- #}
-    <div class="col-lg-7">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-truck me-2 text-info"></i>Entregas de mis obras</strong>
-        </div>
+    {# ---------- Entregas ---------- #}
+    <div class="col-12 col-lg-7">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-truck me-2 text-info"></i>Entregas de mis obras</div>
         <div class="table-responsive">
-          <table class="table table-sm align-middle mb-0">
-            <thead class="table-light">
-              <tr><th>OC</th><th>Proveedor</th><th>Obra</th><th>Estado</th></tr>
-            </thead>
+          <table class="table align-middle mb-0">
+            <thead><tr><th>OC</th><th>Proveedor</th><th>Obra</th><th>Estado</th></tr></thead>
             <tbody>
               {% for e in entregas %}
               <tr>
-                <td><a href="{{ e.url }}" class="text-decoration-none">{{ e.numero }}</a></td>
+                <td><a href="{{ e.url }}" class="obra-name">{{ e.numero }}</a></td>
                 <td>{{ e.proveedor }}</td>
                 <td>{{ e.obra }}</td>
-                <td>
-                  {% if e.vencida %}<span class="badge bg-danger">Vencida ({{ -e.dias }}d)</span>
-                  {% else %}<span class="badge bg-info text-dark">En {{ e.dias }}d</span>{% endif %}
-                </td>
+                <td>{% if e.vencida %}<span class="badge bg-danger">Vencida ({{ -e.dias }}d)</span>{% else %}<span class="badge bg-info-subtle text-info-emphasis border border-info-subtle">En {{ e.dias }}d</span>{% endif %}</td>
               </tr>
               {% else %}
               <tr><td colspan="4" class="text-center text-muted py-4">Sin entregas próximas</td></tr>
@@ -121,21 +144,17 @@
     </div>
 
     {# ---------- Equipo asignado ---------- #}
-    <div class="col-lg-5">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-users me-2 text-secondary"></i>Equipo asignado</strong>
-        </div>
+    <div class="col-12 col-lg-5">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-users me-2 text-secondary"></i>Equipo asignado</div>
         <div class="table-responsive">
-          <table class="table table-sm align-middle mb-0">
-            <thead class="table-light">
-              <tr><th>Persona</th><th>Rol</th><th>Obra</th></tr>
-            </thead>
+          <table class="table align-middle mb-0">
+            <thead><tr><th>Persona</th><th>Rol</th><th>Obra</th></tr></thead>
             <tbody>
               {% for m in equipo %}
               <tr>
                 <td class="fw-semibold">{{ m.usuario }}</td>
-                <td><span class="badge bg-light text-dark">{{ m.rol_en_obra }}</span></td>
+                <td><span class="badge bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle">{{ m.rol_en_obra }}</span></td>
                 <td class="text-muted small">{{ m.obra }}</td>
               </tr>
               {% else %}

--- a/templates/dashboards/tecnico.html
+++ b/templates/dashboards/tecnico.html
@@ -1,44 +1,35 @@
 {% extends "base.html" %}
-{% block title %}Dashboard Técnico | OBYRA{% endblock %}
-
-{% set BADGE = {
-  'FINALIZADA': 'secondary', 'PARADA': 'dark', 'CRITICA': 'danger',
-  'ATRASADA': 'warning', 'EN_CURSO': 'success', 'CANCELADA': 'secondary'
-} %}
+{% from 'dashboards/_dash_macros.html' import estado_badge, estado_color %}
+{% block title %}Mi trabajo | OBYRA{% endblock %}
+{% block extra_head %}{% include 'dashboards/_dash_styles.html' %}{% endblock %}
 
 {% block content %}
-<div class="container-fluid py-4">
+<div class="container-fluid py-4 dash">
   <div class="mb-4">
     <h3 class="mb-0"><i class="fas fa-helmet-safety me-2 text-primary"></i>Mi trabajo</h3>
-    <small class="text-muted">Obras asignadas y stock disponible</small>
+    <span class="text-muted small">Obras asignadas y stock disponible</span>
   </div>
 
   <div class="row g-4">
-    {# ---------- Obras en las que está ---------- #}
-    <div class="col-lg-7">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-building me-2 text-primary"></i>Mis obras</strong>
-        </div>
+    {# ---------- Mis obras ---------- #}
+    <div class="col-12 col-lg-7">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-building me-2 text-primary"></i>Mis obras</div>
         <div class="table-responsive">
-          <table class="table table-sm align-middle mb-0">
-            <thead class="table-light">
-              <tr><th>Obra</th><th style="min-width:120px">Avance</th><th>Estado</th></tr>
-            </thead>
+          <table class="table align-middle mb-0">
+            <thead><tr><th>Obra</th><th class="progress-wrap">Avance</th><th>Estado</th></tr></thead>
             <tbody>
               {% for o in obras %}
               <tr>
                 <td>
-                  <a href="{{ url_for('obras.detalle', id=o.id) }}" class="text-decoration-none fw-semibold">{{ o.nombre }}</a>
+                  <a href="{{ url_for('obras.detalle', id=o.id) }}" class="obra-name">{{ o.nombre }}</a>
                   <div class="text-muted small">{{ o.cliente }}</div>
                 </td>
-                <td>
-                  <div class="progress" style="height:6px">
-                    <div class="progress-bar bg-{{ BADGE.get(o.estado_operativo, 'primary') }}" style="width: {{ o.avance }}%"></div>
-                  </div>
-                  <small class="text-muted">{{ o.avance }}%</small>
+                <td class="progress-wrap">
+                  <div class="progress"><div class="progress-bar bg-{{ estado_color(o.estado_operativo) }}" style="width: {{ o.avance }}%"></div></div>
+                  <span class="text-muted small num">{{ o.avance }}%</span>
                 </td>
-                <td><span class="badge bg-{{ BADGE.get(o.estado_operativo, 'secondary') }}">{{ o.estado_operativo }}</span></td>
+                <td>{{ estado_badge(o.estado_operativo) }}</td>
               </tr>
               {% else %}
               <tr><td colspan="3" class="text-center text-muted py-4">No tenés obras asignadas</td></tr>
@@ -50,21 +41,17 @@
     </div>
 
     {# ---------- Stock disponible ---------- #}
-    <div class="col-lg-5">
-      <div class="card shadow-sm border-0 h-100">
-        <div class="card-header bg-white border-0">
-          <strong><i class="fas fa-boxes-stacked me-2 text-secondary"></i>Stock disponible en obra</strong>
-        </div>
+    <div class="col-12 col-lg-5">
+      <div class="card h-100">
+        <div class="card-header"><i class="fas fa-boxes-stacked me-2 text-secondary"></i>Stock disponible en obra</div>
         <div class="table-responsive">
-          <table class="table table-sm align-middle mb-0">
-            <thead class="table-light">
-              <tr><th>Material</th><th class="text-end">Cantidad</th></tr>
-            </thead>
+          <table class="table align-middle mb-0">
+            <thead><tr><th>Material</th><th class="text-end">Cantidad</th></tr></thead>
             <tbody>
               {% for s in stock %}
               <tr>
                 <td>{{ s.item }}</td>
-                <td class="text-end">{{ "{:,.2f}".format(s.cantidad) }} <span class="text-muted small">{{ s.unidad }}</span></td>
+                <td class="text-end num">{{ "{:,.2f}".format(s.cantidad) }} <span class="text-muted small">{{ s.unidad }}</span></td>
               </tr>
               {% else %}
               <tr><td colspan="2" class="text-center text-muted py-4">Sin stock registrado</td></tr>


### PR DESCRIPTION
Ajustes de UI post-deploy sobre los dashboards por rol (feedback directo sobre el dashboard admin en producción).

## Cambios

### 1. "Roles y Permisos" en el menú
Nuevo item en el dropdown de **Equipos** (`base.html`) → `/equipos/roles`, visible **solo para admin** (`current_user.es_admin()`, mismo patrón que "Gestión de Usuarios"). Antes la pantalla de administración de roles existía pero no era alcanzable desde el nav.

### 2. KPIs del dashboard admin más útiles
- **Sacado el "margen %"** de la portada: cuando la ejecución es baja, `margen_pct` ≈ 100% e informa lo mismo que ejecución pero invertido (parece "buenísimo" sin serlo).
- **Portada nueva:** Presupuesto total · Gastado (real) · **% Ejecución** (con mini-barra) · **Obras atrasadas** (count, rojo si hay).
- El `% del ppto.` debajo del costo real (ej. `0.7%`) **estaba bien calculado** (costo/presupuesto) — solo faltaba el label; ahora dice "X% del ppto." y se pone rojo si pasa 100%.
- `resumen_financiero` gana el campo `obras_atrasadas`.

### 3. Rediseño CSS de los 4 dashboards (admin/pm/tecnico/operario)
- Cards con sombras suaves, radios 16px, jerarquía tipográfica y espaciado.
- **Números grandes formateados**: `$16,337,349,214` → `$5.3B` / `$1.6B` / `$800.0M` (macro `money`).
- Barras de progreso más visibles (coloreadas por estado operativo), badges sutiles por estado (Bootstrap 5.3 `bg-*-subtle`).
- **Responsive 375px**: KPIs se apilan, tablas con scroll horizontal (`.table-responsive` + `min-width`), alertas con `word-break` (no se cortan).
- Solo Bootstrap, sin frameworks nuevos.
- Partials nuevos compartidos: `_dash_macros.html` + `_dash_styles.html`.

## Verificación
- ✅ `py_compile` del service.
- ✅ Smoke 10/10 en el server: los 4 dashboards renderizan 200 con los KPIs nuevos, números `$X.XB`, estados CRÍTICA/ATRASADA, y el item "Roles y Permisos" → `/equipos/roles` en el nav (org demo con 4 obras sembradas).

## Notas
- No toca lógica de negocio (solo templates + un campo derivado en el service).
- Depende del PR #33 (roles) ya mergeado: usa el endpoint `equipos.roles_admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
