### PR TITLE
IA presupuestos Fase 1: base de precios global + fix extracción de precios del parser

### DIFF
--- a/blueprint_presupuestos/importar_licitacion.py
+++ b/blueprint_presupuestos/importar_licitacion.py
@@ -109,11 +109,25 @@ def _match_precio(h_norm):
     return False
 
 
+def _match_total_linea(h_norm):
+    """Columna de importe/precio TOTAL de la linea (no de rubro/seccion).
+
+    Ej JMG: 'precio total item'. Excluye 'precio total rubro' (total de la
+    seccion, no de la fila). Se usa para validar/back-calcular el unitario.
+    """
+    if not h_norm:
+        return False
+    if 'rubro' in h_norm or 'seccion' in h_norm:
+        return False
+    return ('precio total' in h_norm) or ('importe' in h_norm) or ('total item' in h_norm)
+
+
 def _detectar_columnas(headers):
-    """Busca indices de columnas en el header. Retorna dict desc/unidad/cantidad/precio."""
-    idx = {'desc': None, 'unidad': None, 'cantidad': None, 'precio': None}
+    """Busca indices de columnas. Retorna dict desc/unidad/cantidad/precio/total."""
+    idx = {'desc': None, 'unidad': None, 'cantidad': None, 'precio': None, 'total': None}
     norms = [_norm_header(h) for h in headers]
 
+    precio_cands = []  # (score, i) para elegir la MEJOR columna de precio unitario
     for i, hn in enumerate(norms):
         if not hn:
             continue
@@ -123,9 +137,78 @@ def _detectar_columnas(headers):
             idx['unidad'] = i
         if idx['cantidad'] is None and _match_cantidad(hn):
             idx['cantidad'] = i
-        if idx['precio'] is None and _match_precio(hn):
-            idx['precio'] = i
+        if idx['total'] is None and _match_total_linea(hn):
+            idx['total'] = i
+        if _match_precio(hn):
+            # Penalizar sub-columnas de desglose APU (MO/MAT, suelen venir en $0);
+            # premiar 'total' (sub-total unitario del grupo) y 'unitario' explicito.
+            sc = 0
+            if 'mano de obra' in hn or 'materiales' in hn or hn.endswith(' mo') or hn.endswith('m.o'):
+                sc -= 5
+            if 'total' in hn:
+                sc += 2
+            if 'unitario' in hn:
+                sc += 1
+            precio_cands.append((sc, i))
+
+    if precio_cands:
+        precio_cands.sort(key=lambda x: (-x[0], x[1]))
+        idx['precio'] = precio_cands[0][1]
     return idx
+
+
+def _detectar_columna_precio_unitario(rows, start_data, idx):
+    """Detecta la columna de precio UNITARIO por validacion aritmetica:
+
+    es la columna X donde `X * cantidad ~= total_de_linea` en la mayoria de las
+    filas de muestra. Robusto ante layouts multi-columna (MANO DE OBRA |
+    MATERIALES | TOTAL) donde el header no distingue la sub-columna correcta y
+    el detector cae en una sub-columna en $0 (bug JMG).
+
+    Devuelve el indice de columna validado, o None si no puede validar.
+    """
+    col_cant = idx.get('cantidad')
+    col_total = idx.get('total')
+    if col_cant is None or col_total is None:
+        return None
+
+    ventana = rows[start_data:start_data + 40]
+    max_col = max((len(r) for r in ventana), default=0)
+    if not max_col:
+        return None
+
+    aciertos = {}
+    muestras = 0
+    for row in ventana:
+        if not row or col_cant >= len(row) or col_total >= len(row):
+            continue
+        try:
+            cant = _parse_decimal(row[col_cant])
+            total = _parse_decimal(row[col_total])
+        except Exception:
+            continue
+        if cant <= 0 or total <= 0:
+            continue
+        muestras += 1
+        for c in range(max_col):
+            if c in (col_cant, col_total) or c >= len(row):
+                continue
+            try:
+                val = _parse_decimal(row[c])
+            except Exception:
+                continue
+            if val <= 0:
+                continue
+            # tolerancia 1.5% (los totales suelen venir redondeados)
+            if abs(val * cant - total) <= (total * Decimal('0.015')):
+                aciertos[c] = aciertos.get(c, 0) + 1
+
+    if not aciertos or muestras == 0:
+        return None
+    mejor = max(aciertos, key=lambda c: aciertos[c])
+    if aciertos[mejor] >= max(2, muestras // 2):
+        return mejor
+    return None
 
 
 def _construir_header_combinado(rows, header_idx):
@@ -266,6 +349,13 @@ def _parsear_xlsx(file_stream):
         if idx['desc'] is None or idx['cantidad'] is None:
             continue
 
+        # Refinar la columna de precio UNITARIO por validacion aritmetica
+        # (X * cantidad ~= total_linea). Corrige planillas tipo JMG donde el
+        # header apunta a una sub-columna de desglose (MO/MAT) que viene en $0.
+        col_precio_val = _detectar_columna_precio_unitario(rows, start_data, idx)
+        if col_precio_val is not None:
+            idx['precio'] = col_precio_val
+
         # Saltar sub-header tipico solo si la fila siguiente parece extra ("$/un", "$/total")
         if start_data < len(rows):
             sub = rows[start_data]
@@ -353,12 +443,27 @@ def _parsear_xlsx(file_stream):
             except Exception:
                 precio_d = Decimal('0')
 
+            # Total de linea declarado por el header (si existe)
+            total_d = None
+            if idx.get('total') is not None and idx['total'] < len(row):
+                try:
+                    total_d = _parse_decimal(row[idx['total']])
+                except Exception:
+                    total_d = None
+
+            # Fallback: si el unitario quedo en 0 pero hay total de linea + cantidad,
+            # back-calcular el unitario (planillas con el precio en sub-columna).
+            if (precio_d is None or precio_d <= 0) and total_d and total_d > 0 and cantidad_d > 0:
+                precio_d = total_d / cantidad_d
+
+            total_final = total_d if (total_d and total_d > 0) else (cantidad_d * precio_d)
+
             items_total.append({
                 'descripcion': desc[:300],
                 'unidad': str(unidad).strip()[:20] if unidad else 'un',
                 'cantidad': cantidad_d,
                 'precio_unitario': precio_d,
-                'total': cantidad_d * precio_d,
+                'total': total_final,
                 'etapa_nombre': etapa_actual,
                 'codigo': codigo,
                 # Fase 6.A: trazabilidad de origen para multi-archivo

--- a/migrations/versions/20260715_ppl_org_nullable_global.py
+++ b/migrations/versions/20260715_ppl_org_nullable_global.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""provider_price_list: organizacion_id nullable (base global) + unique COALESCE
+
+Revision ID: 202607150001
+Revises: 202607130002
+Create Date: 2026-07-15
+
+Fase 1 IA presupuestos — base de precios global:
+  1. `organizacion_id` pasa a NULLABLE. NULL = base global OBYRA (accesible por
+     todas las orgs via el fallback de precio_recurso_service; los precios de
+     una org pisan la global).
+  2. El indice UNIQUE se recrea con COALESCE(organizacion_id, 0) para que las
+     filas globales (org NULL) deduped entre si (antes usaba organizacion_id
+     directo, y Postgres trata cada NULL como distinto -> permitiria duplicados).
+
+No mueve datos: la migracion de filas existentes a NULL se hace aparte (por
+org, contra la base cargada), para no tocar listas propias org-especificas.
+Idempotente.
+"""
+from alembic import op
+
+
+revision = '202607150001'
+down_revision = '202607130002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1) organizacion_id nullable
+    op.execute("ALTER TABLE provider_price_list ALTER COLUMN organizacion_id DROP NOT NULL")
+
+    # 2) recrear el UNIQUE con COALESCE(organizacion_id, 0)
+    op.execute("DROP INDEX IF EXISTS uq_ppl_org_prov_desc_un_zona_modalidad")
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_ppl_org_prov_desc_un_zona_modalidad
+            ON provider_price_list(
+                COALESCE(organizacion_id, 0),
+                COALESCE(proveedor_id, 0),
+                descripcion_normalizada,
+                unidad,
+                COALESCE(zona, ''),
+                COALESCE(modalidad, 'compra')
+            )
+    """)
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS uq_ppl_org_prov_desc_un_zona_modalidad")
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_ppl_org_prov_desc_un_zona_modalidad
+            ON provider_price_list(
+                organizacion_id, COALESCE(proveedor_id, 0),
+                descripcion_normalizada, unidad,
+                COALESCE(zona, ''), COALESCE(modalidad, 'compra')
+            )
+    """)
+    # NOTA: no se re-agrega NOT NULL en downgrade (podria haber filas globales).

--- a/models/provider_price_list.py
+++ b/models/provider_price_list.py
@@ -57,8 +57,12 @@ class ProviderPriceList(db.Model):
     )
 
     id = db.Column(db.Integer, primary_key=True)
+    # nullable=True: organizacion_id NULL = BASE GLOBAL de precios OBYRA (Fase 1
+    # IA presupuestos). Los precios de una org (organizacion_id = X) pisan la
+    # base global en _buscar_provider_price_list. La unicidad usa
+    # COALESCE(organizacion_id, 0) para que las filas globales deduped entre si.
     organizacion_id = db.Column(db.Integer, db.ForeignKey('organizaciones.id', ondelete='CASCADE'),
-                                nullable=False, index=True)
+                                nullable=True, index=True)
     proveedor_id = db.Column(db.Integer, db.ForeignKey('proveedores_oc.id', ondelete='SET NULL'),
                              nullable=True)
     descripcion = db.Column(db.String(300), nullable=False)

--- a/runtime_migrations.py
+++ b/runtime_migrations.py
@@ -2195,6 +2195,28 @@ def run_runtime_migrations(db, app):
         db.session.rollback()
         print(f"[WARN] provider_price_list: {e}")
 
+    # Fase 1 IA presupuestos: organizacion_id nullable (base global) + UNIQUE con
+    # COALESCE(organizacion_id, 0) para que las filas globales deduped entre si.
+    try:
+        db.session.execute(db.text("""
+            ALTER TABLE provider_price_list ALTER COLUMN organizacion_id DROP NOT NULL;
+            DROP INDEX IF EXISTS uq_ppl_org_prov_desc_un_zona_modalidad;
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_ppl_org_prov_desc_un_zona_modalidad
+                ON provider_price_list(
+                    COALESCE(organizacion_id, 0),
+                    COALESCE(proveedor_id, 0),
+                    descripcion_normalizada,
+                    unidad,
+                    COALESCE(zona, ''),
+                    COALESCE(modalidad, 'compra')
+                );
+        """))
+        db.session.commit()
+        print("[OK] provider_price_list: organizacion_id nullable + unique COALESCE (base global)")
+    except Exception as e:
+        db.session.rollback()
+        print(f"[WARN] provider_price_list base global: {e}")
+
     try:
         db.session.execute(db.text("""
         DO $$ BEGIN

--- a/scripts/cargar_base_precios.py
+++ b/scripts/cargar_base_precios.py
@@ -1,0 +1,43 @@
+"""Carga la base de precios OBYRA (catalogo ~6.345 recursos) a ProviderPriceList.
+
+Fase 1 — IA de presupuestos. Idempotente: correr 2 veces actualiza precios,
+no duplica (clave: org + desc_normalizada + unidad + zona).
+
+Uso:
+    python scripts/cargar_base_precios.py --org-id 8 \
+        --xlsx "C:/Users/ECSA/Desktop/BREN/PRECIOS OBYRA/OBYRA_base_precios_recursos_v1.xlsx"
+
+La base se carga POR ORGANIZACION (ProviderPriceList es multi-tenant y
+precio_recurso_service la consulta filtrando por organizacion_id, sin fallback
+global). Para que otra org la use, correr con su --org-id.
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_DEFAULT_XLSX = r"C:\Users\ECSA\Desktop\BREN\PRECIOS OBYRA\OBYRA_base_precios_recursos_v1.xlsx"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Cargar base de precios OBYRA a ProviderPriceList")
+    ap.add_argument("--org-id", type=int, required=True, help="ID de la organizacion destino")
+    ap.add_argument("--xlsx", default=_DEFAULT_XLSX, help="Ruta al OBYRA_base_precios_recursos_v1.xlsx")
+    ap.add_argument("--user-id", type=int, default=None, help="ID del usuario que carga (opcional)")
+    args = ap.parse_args()
+
+    import app as _app
+    from extensions import db
+    with _app.app.app_context():
+        from services.importer_lista_propia import importar_catalogo_base
+        res = importar_catalogo_base(
+            db=db, xlsx_path=args.xlsx, organizacion_id=args.org_id, user_id=args.user_id,
+        )
+        print("Resultado:", res)
+        if not res.get("ok"):
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cargar_base_precios.py
+++ b/scripts/cargar_base_precios.py
@@ -22,9 +22,13 @@ _DEFAULT_XLSX = r"C:\Users\ECSA\Desktop\BREN\PRECIOS OBYRA\OBYRA_base_precios_re
 
 def main():
     ap = argparse.ArgumentParser(description="Cargar base de precios OBYRA a ProviderPriceList")
-    ap.add_argument("--org-id", type=int, required=True, help="ID de la organizacion destino")
+    ap.add_argument("--org-id", type=int, required=True,
+                    help="ID de organizacion para el ImportBatch (trazabilidad). Con --global "
+                         "los precios se cargan como base global; sin --global, para esa org.")
     ap.add_argument("--xlsx", default=_DEFAULT_XLSX, help="Ruta al OBYRA_base_precios_recursos_v1.xlsx")
     ap.add_argument("--user-id", type=int, default=None, help="ID del usuario que carga (opcional)")
+    ap.add_argument("--global", dest="global_base", action=argparse.BooleanOptionalAction,
+                    default=True, help="Cargar como BASE GLOBAL (org NULL). Default: True.")
     args = ap.parse_args()
 
     import app as _app
@@ -33,6 +37,7 @@ def main():
         from services.importer_lista_propia import importar_catalogo_base
         res = importar_catalogo_base(
             db=db, xlsx_path=args.xlsx, organizacion_id=args.org_id, user_id=args.user_id,
+            global_base=args.global_base,
         )
         print("Resultado:", res)
         if not res.get("ok"):

--- a/services/importer_lista_propia.py
+++ b/services/importer_lista_propia.py
@@ -533,6 +533,7 @@ def importar_catalogo_base(
     organizacion_id: int,
     user_id: "Optional[int]" = None,
     perfil: str = 'lista_propia_obyra',
+    global_base: bool = False,
 ) -> "Dict[str, Any]":
     """Importa el catalogo COMPLETO (hoja 01 ~6.345 + hoja 02 zonas + MO) a
     provider_price_list de forma IDEMPOTENTE y eficiente.
@@ -546,6 +547,11 @@ def importar_catalogo_base(
 
     if not os.path.exists(xlsx_path):
         return {'ok': False, 'error': f'archivo no encontrado: {xlsx_path}'}
+
+    # global_base=True -> los precios se cargan como BASE GLOBAL (org NULL),
+    # accesibles por todas las orgs via el fallback de precio_recurso_service.
+    # El ImportBatch sigue bajo `organizacion_id` (solo trazabilidad).
+    org_precios = None if global_base else organizacion_id
 
     filename = os.path.basename(xlsx_path)
     checksum = _calcular_checksum(xlsx_path)
@@ -580,10 +586,12 @@ def importar_catalogo_base(
     except ValueError:  # 29-feb
         vigencia = date(hoy.year + 1, hoy.month, 28)
 
-    # Pre-cargar claves existentes de la org (proveedor NULL) -> UPSERT O(1).
+    # Pre-cargar claves existentes (proveedor NULL) del scope destino -> UPSERT O(1).
     existentes = {}
+    _org_filter = (ProviderPriceList.organizacion_id.is_(None) if org_precios is None
+                   else ProviderPriceList.organizacion_id == org_precios)
     for r in (ProviderPriceList.query
-              .filter(ProviderPriceList.organizacion_id == organizacion_id,
+              .filter(_org_filter,
                       ProviderPriceList.proveedor_id.is_(None))
               .all()):
         existentes[(r.descripcion_normalizada, r.unidad, r.zona)] = r
@@ -619,7 +627,7 @@ def importar_catalogo_base(
                 updated += 1
         else:
             row = ProviderPriceList(
-                organizacion_id=organizacion_id, proveedor_id=None,
+                organizacion_id=org_precios, proveedor_id=None,
                 descripcion=desc[:300], descripcion_normalizada=desc_norm, unidad=unidad,
                 precio_unitario=precio, moneda=moneda, fecha_actualizacion=hoy,
                 vigencia_hasta=vigencia, fuente=perfil[:30], zona=zona, modalidad='compra',

--- a/services/importer_lista_propia.py
+++ b/services/importer_lista_propia.py
@@ -449,3 +449,202 @@ def deshacer_batch(*, db, batch_id: int, motivo: str = '',
         'rows_ppl_borradas': rows_ppl,
         'rows_po_borradas': rows_po,
     }
+
+
+# ============================================================================
+# Fase 1 IA presupuestos: carga del CATALOGO COMPLETO (hoja 01, ~6.345 filas)
+# ============================================================================
+
+def _parse_hoja_01_catalogo(xlsx_path: str) -> "List[Dict[str, Any]]":
+    """Parsea la hoja '01_Catalogo_OBYRA' del OBYRA_base_precios_recursos_v1.
+
+    Es el catalogo normalizado (~6.345 filas). Header en fila 1:
+      fuente | proveedor | categoria | tipo_recurso | recurso | descripcion |
+      unidad | precio_min | precio_max | precio_unitario
+
+    La hoja 01 NO trae zona (zona=None). Si `unidad` esta vacia se infiere de
+    la descripcion. Si `precio_unitario` esta vacio se usa el promedio de
+    precio_min/precio_max.
+    """
+    import openpyxl
+    if not os.path.exists(xlsx_path):
+        return []
+    wb = openpyxl.load_workbook(xlsx_path, data_only=True, read_only=True)
+    if '01_Catalogo_OBYRA' not in wb.sheetnames:
+        wb.close()
+        return []
+    ws = wb['01_Catalogo_OBYRA']
+    rows = list(ws.iter_rows(values_only=True))
+    wb.close()
+    if len(rows) < 2:
+        return []
+
+    header = [(_normalizar_unidad_str(str(c)) if c else '') for c in rows[0]]
+    col_idx = {h: i for i, h in enumerate(header)}
+
+    def _g(row, key, default=None):
+        i = col_idx.get(key)
+        if i is None or i >= len(row):
+            return default
+        return row[i]
+
+    salida = []
+    for row in rows[1:]:
+        if not row or all(c is None for c in row):
+            continue
+        recurso = _g(row, 'recurso')
+        descripcion = _g(row, 'descripcion') or recurso
+        if not recurso and not descripcion:
+            continue
+        unidad_raw = _g(row, 'unidad')
+        unidad = _normalizar_unidad_str(unidad_raw) if unidad_raw else ''
+        if not unidad:
+            unidad = _inferir_unidad_de_descripcion(str(recurso or descripcion or ''))
+        precio_unit = _decimal_safe(_g(row, 'precio_unitario'))
+        if not precio_unit:
+            pmin = _decimal_safe(_g(row, 'precio_min'))
+            pmax = _decimal_safe(_g(row, 'precio_max'))
+            if pmin and pmax:
+                precio_unit = (pmin + pmax) / Decimal('2')
+            elif pmin:
+                precio_unit = pmin
+            elif pmax:
+                precio_unit = pmax
+        if not precio_unit:
+            continue
+        salida.append({
+            'descripcion': str(descripcion).strip()[:300],
+            'recurso': str(recurso).strip()[:300] if recurso else None,
+            'unidad': unidad[:20] or 'un',
+            'zona': None,  # hoja 01 no trae zona
+            'moneda': 'ARS',
+            'precio_unitario': precio_unit,
+            'tipo_recurso': (str(_g(row, 'tipo_recurso') or 'material')).strip().lower()[:20],
+            'categoria': (str(_g(row, 'categoria') or '')).strip()[:120] or None,
+            'fuente_excel': (str(_g(row, 'fuente') or 'OBYRA_base_v1.01_Catalogo'))[:80],
+        })
+    return salida
+
+
+def importar_catalogo_base(
+    *,
+    db,
+    xlsx_path: str,
+    organizacion_id: int,
+    user_id: "Optional[int]" = None,
+    perfil: str = 'lista_propia_obyra',
+) -> "Dict[str, Any]":
+    """Importa el catalogo COMPLETO (hoja 01 ~6.345 + hoja 02 zonas + MO) a
+    provider_price_list de forma IDEMPOTENTE y eficiente.
+
+    Idempotente: clave de unicidad (org, proveedor=NULL, desc_norm, unidad,
+    zona). Correr 2 veces ACTUALIZA precio, no duplica. Se pre-cargan las claves
+    existentes en memoria para hacer el UPSERT sin N+1.
+    """
+    from models.import_batch import ImportBatch
+    from models.provider_price_list import ProviderPriceList, normalizar_descripcion_precio
+
+    if not os.path.exists(xlsx_path):
+        return {'ok': False, 'error': f'archivo no encontrado: {xlsx_path}'}
+
+    filename = os.path.basename(xlsx_path)
+    checksum = _calcular_checksum(xlsx_path)
+    # Idempotencia a nivel batch: ImportBatch tiene UNIQUE(org, checksum). Si ya
+    # se importo este mismo archivo para esta org, se REUTILIZA el batch.
+    batch = (ImportBatch.query
+             .filter_by(organizacion_id=organizacion_id, checksum_sha256=checksum)
+             .first())
+    if batch is not None:
+        batch.perfil = perfil
+        batch.estado = 'en_curso'
+        batch.started_at = datetime.utcnow()
+        batch.user_id = user_id or batch.user_id
+    else:
+        batch = ImportBatch(
+            organizacion_id=organizacion_id, perfil=perfil, filename=filename[:255],
+            checksum_sha256=checksum, user_id=user_id,
+            estado='en_curso', started_at=datetime.utcnow(),
+        )
+        db.session.add(batch)
+    db.session.flush()
+
+    filas = (
+        _parse_hoja_01_catalogo(xlsx_path)
+        + _parse_hoja_02_materiales(xlsx_path)
+        + _parse_hoja_import_obyra_mano_obra(xlsx_path)
+    )
+
+    hoy = date.today()
+    try:
+        vigencia = date(hoy.year + 1, hoy.month, hoy.day)
+    except ValueError:  # 29-feb
+        vigencia = date(hoy.year + 1, hoy.month, 28)
+
+    # Pre-cargar claves existentes de la org (proveedor NULL) -> UPSERT O(1).
+    existentes = {}
+    for r in (ProviderPriceList.query
+              .filter(ProviderPriceList.organizacion_id == organizacion_id,
+                      ProviderPriceList.proveedor_id.is_(None))
+              .all()):
+        existentes[(r.descripcion_normalizada, r.unidad, r.zona)] = r
+
+    inserted = updated = invalid = 0
+    vistas = set()
+    for fila in filas:
+        desc = fila['descripcion']
+        desc_norm = normalizar_descripcion_precio(desc)
+        unidad = fila['unidad']
+        zona = fila.get('zona')
+        precio = fila['precio_unitario']
+        moneda = (fila.get('moneda') or 'ARS')[:3]
+        if not desc_norm or not precio or precio <= 0:
+            invalid += 1
+            continue
+        key = (desc_norm, unidad, zona)
+        notas = (f"Base precios OBYRA. Cat: {fila.get('categoria') or '-'} · "
+                 f"tipo: {fila.get('tipo_recurso') or '-'} · "
+                 f"Excel: {fila.get('fuente_excel') or '-'}")[:1000]
+
+        row = existentes.get(key)
+        if row is not None:
+            row.precio_unitario = precio
+            row.moneda = moneda
+            row.fecha_actualizacion = hoy
+            row.vigencia_hasta = vigencia
+            row.fuente = perfil[:30]
+            row.import_batch_id = batch.id
+            row.modalidad = 'compra'
+            row.notas = notas
+            if key not in vistas:
+                updated += 1
+        else:
+            row = ProviderPriceList(
+                organizacion_id=organizacion_id, proveedor_id=None,
+                descripcion=desc[:300], descripcion_normalizada=desc_norm, unidad=unidad,
+                precio_unitario=precio, moneda=moneda, fecha_actualizacion=hoy,
+                vigencia_hasta=vigencia, fuente=perfil[:30], zona=zona, modalidad='compra',
+                import_batch_id=batch.id, created_by_user_id=user_id, notas=notas,
+            )
+            db.session.add(row)
+            existentes[key] = row
+            inserted += 1
+        vistas.add(key)
+
+    batch.total_input = len(filas)
+    batch.total_inserted = inserted
+    batch.total_updated = updated
+    batch.total_invalid = invalid
+    batch.estado = 'completado'
+    batch.completed_at = datetime.utcnow()
+
+    try:
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        return {'ok': False, 'error': f'{type(e).__name__}: {e}'}
+
+    return {
+        'ok': True, 'batch_id': batch.id, 'total_input': len(filas),
+        'inserted': inserted, 'updated': updated, 'invalid': invalid,
+        'unicos_en_run': len(vistas),
+    }

--- a/services/precio_recurso_service.py
+++ b/services/precio_recurso_service.py
@@ -280,31 +280,41 @@ def _buscar_provider_price_list(organizacion_id, descripcion_norm, unidad, item_
     """
     from models.provider_price_list import ProviderPriceList
 
+    # Fase 1 IA: buscar en los precios de la ORG y en la BASE GLOBAL (org NULL).
+    # Los precios propios de la org PISAN la base global -> se ordena poniendo
+    # primero las filas de la org (_org_first) y en fuzzy se les da un bonus.
+    _scope = db.or_(ProviderPriceList.organizacion_id == organizacion_id,
+                    ProviderPriceList.organizacion_id.is_(None))
+    # org propio (0) antes que global (1). CASE, no boolean.desc(): para las
+    # filas globales `org == X` da NULL y en Postgres NULL ordena primero en
+    # DESC, lo que dejaba ganar a la global sobre el precio propio de la org.
+    _org_first = db.case((ProviderPriceList.organizacion_id == organizacion_id, 0), else_=1)
+
     # Prioridad 0: matching por item_inventario_id (mas fuerte)
     if item_inventario_id:
         candidatos = (ProviderPriceList.query
-                      .filter(ProviderPriceList.organizacion_id == organizacion_id,
+                      .filter(_scope,
                               ProviderPriceList.item_inventario_id == item_inventario_id)
-                      .order_by(ProviderPriceList.fecha_actualizacion.desc())
+                      .order_by(_org_first, ProviderPriceList.fecha_actualizacion.desc())
                       .all())
         if candidatos:
             return candidatos[0], candidatos[1:6]
 
     # Prioridad 1: descripcion_normalizada exacto + unidad exacta
     candidatos = (ProviderPriceList.query
-                  .filter(ProviderPriceList.organizacion_id == organizacion_id,
+                  .filter(_scope,
                           ProviderPriceList.unidad == unidad,
                           ProviderPriceList.descripcion_normalizada == descripcion_norm)
-                  .order_by(ProviderPriceList.fecha_actualizacion.desc())
+                  .order_by(_org_first, ProviderPriceList.fecha_actualizacion.desc())
                   .all())
     if candidatos:
         return candidatos[0], candidatos[1:6]
 
     # Prioridad 2: descripcion exacta con unidad compatible (sinónimos)
     candidatos_desc_exacta = (ProviderPriceList.query
-                              .filter(ProviderPriceList.organizacion_id == organizacion_id,
+                              .filter(_scope,
                                       ProviderPriceList.descripcion_normalizada == descripcion_norm)
-                              .order_by(ProviderPriceList.fecha_actualizacion.desc())
+                              .order_by(_org_first, ProviderPriceList.fecha_actualizacion.desc())
                               .all())
     matches_compatibles = [c for c in candidatos_desc_exacta if _unidades_compatibles(c.unidad, unidad)]
     if matches_compatibles:
@@ -316,14 +326,13 @@ def _buscar_provider_price_list(organizacion_id, descripcion_norm, unidad, item_
     if not tokens_item:
         return None, []
 
-    # Traer todos los precios del org (limitado a 500 para no explotar memoria).
-    # En producción real con miles de filas habría que filtrar antes por
-    # prefijo o algún heurístico. Para demo y JMG (≤200 items, lista propia
-    # ≤300 filas), 500 alcanza sin problema.
+    # Traer precios de la org + base global. Con la base OBYRA (~6.3k recursos)
+    # el cap se sube; el orden pone primero las filas de la org. (Optimizacion
+    # futura: pre-filtrar por token/prefijo antes del scan en Python.)
     todos = (ProviderPriceList.query
-             .filter(ProviderPriceList.organizacion_id == organizacion_id)
-             .order_by(ProviderPriceList.fecha_actualizacion.desc())
-             .limit(500)
+             .filter(_scope)
+             .order_by(_org_first, ProviderPriceList.fecha_actualizacion.desc())
+             .limit(8000)
              .all())
 
     scored = []
@@ -339,7 +348,9 @@ def _buscar_provider_price_list(organizacion_id, descripcion_norm, unidad, item_
             continue
         # Bonus si la unidad es compatible
         unidad_bonus = 0.2 if _unidades_compatibles(c.unidad, unidad) else 0.0
-        score = jaccard + unidad_bonus
+        # Bonus si es precio propio de la org (pisa la base global en empates)
+        org_bonus = 0.5 if c.organizacion_id == organizacion_id else 0.0
+        score = jaccard + unidad_bonus + org_bonus
         scored.append((score, c))
 
     if not scored:


### PR DESCRIPTION
Fundación (sin IA) para el motor de presupuestos automáticos desde Excel.

## 1. Base de precios OBYRA cargada
- `importer_lista_propia.importar_catalogo_base` (parsea hoja `01_Catalogo_OBYRA`, ~6.345 recursos) + `scripts/cargar_base_precios.py`. UPSERT idempotente por (org|global, desc_norm, unidad, zona), reutiliza el import_batch.
- **Base GLOBAL**: `provider_price_list.organizacion_id` ahora nullable; `NULL` = base OBYRA compartida por todas las orgs. Los precios propios de una org **pisan** la global. Migración `202607150001` (nullable + unique con `COALESCE(org,0)`).
- `_buscar_provider_price_list`: busca org + global con org-first (CASE) y bonus org en el fuzzy. **Verificado**: global consultable, override de org gana, sin fuga entre orgs.

## 2. Fix extracción de precios del parser
- `_parsear_xlsx`: detecta la columna de **total de línea** + **validación aritmética** (`X·cantidad ≈ total`) para elegir el precio unitario real en layouts multi-columna (MO|MAT|TOTAL).
- **JMG re-testeado: 0/112 → 109/112** con precio correcto (los 3 restantes tienen texto "incluido en etapa", sin número — correcto).
- Decisión: fixear `importar_licitacion` en vez de migrar a `excel_budget_parser` (ya clavaba estructura 112/112; solo fallaba en precios).

## Verificación
- `py_compile` de todo · Loader idempotente (run 2 = 0 inserted / 6.348 updated) · Fallback org/global verificado end-to-end.

## Notas
- El histórico en `PrecioObservado` se deja para más adelante (acordado).
- Fuzzy sobre ~6.3k recursos: cap subido a 8k + org-first. Optimización (pre-filtro por token) queda para Fase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
